### PR TITLE
estimate_rit function

### DIFF
--- a/R/estimate_RIT.R
+++ b/R/estimate_RIT.R
@@ -53,22 +53,15 @@ estimate_rit <- function(
   
   # return error if student does not have take a test for given measurementscale
   if (nrow(student) == 0) {
-    
     warning('student does not have a test for given measurementscale')
     return(NA)
-    
   } else if (nrow(student) == 1) {
-    
     if (as.numeric(abs(as.Date(target_date) - student$teststartdate)) <= num_days) {
-      
       warning('student only has one test event for given measurementscale')
       return(student$testritscore[1])
-      
     } else {
-      
       warning('no test score within num_days')
       return(NA)
-      
     }
   }
   

--- a/R/estimate_RIT.R
+++ b/R/estimate_RIT.R
@@ -52,7 +52,7 @@ estimate_rit <- function(
     
   } else if (nrow(student) == 1) {
     
-    if (as.numeric(abs(as.Date(target_date) - student$teststartdate)) <= 180) {
+    if (as.numeric(abs(as.Date(target_date) - student$teststartdate)) <= num_days) {
       
       warning('student only has one test event for given measurementscale')
       return(student$testritscore[1])

--- a/R/estimate_RIT.R
+++ b/R/estimate_RIT.R
@@ -24,11 +24,18 @@ estimate_rit <- function(
   forward = TRUE
 ) {
   
-  # throw an error if method is not given
+  # check that method is given / valid
   if (missing(method)) {
     stop('method not given')
   } else if (!(method %in% c('closest','lm','interpolate'))) {
     stop('method not available')
+  }
+  
+  # check that measurementscale is given / valid
+  if (missing(measurementscale)) {
+    stop('mesaurementscale not given')
+  } else if (!(measurementscale %in% c('General Science','Language Usage','Mathematics','Reading'))) {
+    stop('invalid measurementscale')
   }
 
 

--- a/R/estimate_RIT.R
+++ b/R/estimate_RIT.R
@@ -1,0 +1,96 @@
+#' @title estimate RIT score for a student using regression or interpolation
+#' 
+#' @description Given studentid, measurementscale, and a target_date, the 
+#' function will return an estimated score based on selected method 
+#' 
+#' @param mapvizieR_obj mapvizieR object
+#' @param sid target studentid
+#' @param measurescale target subject
+#' @param target_date date of interest, %Y-%m-%d format
+#' @param method which method to use to estimate RIT score
+#' @param foward default is TRUE, set to FALSE if only scores before target_date should be chosen for 'closest' method
+#' 
+#' @export
+
+
+estimate_rit <- function(
+  mapvizieR_obj,
+  sid,
+  measurescale,
+  target_date,
+  method = c('closest','lm','interpolate'),
+  forward = TRUE
+) {
+  
+  # throw an error if method is not given
+  if (missing(method)) {
+    stop('method not given')
+  }
+  
+  # pull out the cdf
+  cdf <- mapvizieR_obj[['cdf']]
+  
+  target_date <- as.Date(target_date)
+  
+  # find the matchings rows
+  if (require(dplyr)) {
+    student <- cdf %>% dplyr::filter(studentid == sid,
+                                     measurementscale == measurescale)
+  } else {
+    student <- subset(cdf, studentid == sid & measurementscale == measurescale)
+  }
+  
+  # return error if student does not have take a test for given measurementscale
+  if (dim(student)[1] == 0) {
+    warning('student does not have a test for given measurementscale')
+    return(NA)
+  }
+  
+  # if target_date is one of the test dates, return that rit score
+  if (target_date %in% student$teststartdate) {
+    return(student$testritscore[student$teststartdate == target_date])
+  }
+  
+  # change target_date to data.frame to use for prediction
+  predict_date <- data.frame(teststartdate = as.Date(target_date))
+  
+  if (method == 'closest') {
+    # filter out rows if forward = FALSE
+    if (!forward) {
+      student <- student[student$teststartdate < as.Date(target_date),]
+    }
+    student <- student[order(student$teststartdate),]
+    
+    # find closest date and return rit score on that day
+    diff <- as.numeric(as.Date(target_date) - student$teststartdate)
+    
+    return(student$testritscore[match(min(abs(diff)),abs(diff))])
+    
+  } else if (method == 'lm') {
+    fit <- lm(testritscore~teststartdate,student)
+    
+    return(round(predict(fit,newdata = predict_date)))
+    
+  } else if (method == 'interpolate' & (target_date < min(student$teststartdate) | target_date > max(student$teststartdate))) {
+    
+    warning('Cannot interpolate a date before earliest or after latest teststartdate')
+    return(NA)
+  
+  } else if (method =='interpolate') {
+    # order student rows by date
+    student <- student[order(student$teststartdate),]
+    
+    diff <- as.numeric(as.Date(target_date) - student$teststartdate)
+    
+    # get the indices of the test dates that surround the target_date
+    loc <- match(min(abs(diff)),abs(diff))
+    if(diff[loc] > 0) {
+      loc2 <- loc + 1
+    } else {
+      loc2 <- loc - 1
+    }
+    
+    fit <- lm(testritscore~teststartdate,student[sort(c(loc,loc2)),])
+    return(round(predict(fit,newdata=predict_date)))
+  }
+}

--- a/R/estimate_RIT.R
+++ b/R/estimate_RIT.R
@@ -42,8 +42,15 @@ estimate_rit <- function(
   
   # return error if student does not have take a test for given measurementscale
   if (dim(student)[1] == 0) {
+    
     warning('student does not have a test for given measurementscale')
     return(NA)
+    
+  } else if (dim(student)[1] == 1) {
+    
+    warning('student only has one test event for given measurementscale')
+    return(student$testritscore[1])
+    
   }
   
   # if target_date is one of the test dates, return that rit score
@@ -55,7 +62,7 @@ estimate_rit <- function(
   predict_date <- data.frame(teststartdate = as.Date(target_date))
   
   if (method == 'closest') {
-    # filter out rows if forward = FALSE
+    # filter out rows after target date if forward = FALSE
     if (!forward) {
       student <- student[student$teststartdate < as.Date(target_date),]
     }

--- a/R/nearest_RIT.R
+++ b/R/nearest_RIT.R
@@ -34,6 +34,7 @@ nearest_rit <- function(
   if (!forward) {
     student <- student[student$teststartdate <= as.Date(target_date),]
   }
+  student <- student[order(student$teststartdate),]
 
   # find closest date and return rit score on that day
   diff <- as.numeric(as.Date(target_date) - student$teststartdate)

--- a/R/nearest_RIT.R
+++ b/R/nearest_RIT.R
@@ -3,9 +3,10 @@
 #' @description Given studentid, measurementscale, and a target_date, the function will return the closest RIT score. 
 #' 
 #' @param mapvizieR_obj mapvizieR object
-#' @param sid target studentid
-#' @param measurescale target subject
+#' @param studentid target studentid
+#' @param measurementscale target subject
 #' @param target_date date of interest, %Y-%m-%d format
+#' @param num_days function will only return test score within num_days of target_date
 #' @param foward default is TRUE, set to FALSE if only scores before target_date should be chosen
 #' 
 #' @export
@@ -13,9 +14,10 @@
 
 nearest_rit <- function(
   mapvizieR_obj,
-  sid,
-  measurescale,
+  studentid,
+  measurementscale,
   target_date,
+  num_days=180,
   forward=TRUE
 ) {
 
@@ -23,12 +25,7 @@ nearest_rit <- function(
   cdf <- mapvizieR_obj[['cdf']]
   
   # find the matchings rows
-  if (require(dplyr)) {
-    student <- cdf %>% dplyr::filter(studentid == sid,
-                                     measurementscale == measurescale)
-  } else {
-    student <- subset(cdf, studentid == sid & measurementscale == measurescale)
-  }
+  student <- cdf[(cdf$studentid == studentid & cdf$measurementscale == measurementscale),]
 
   # filter out rows if forward = FALSE
   if (!forward) {
@@ -39,6 +36,12 @@ nearest_rit <- function(
   # find closest date and return rit score on that day
   diff <- as.numeric(as.Date(target_date) - student$teststartdate)
   
-  return(student$testritscore[match(min(abs(diff)),abs(diff))])
+  if (min(abs(diff)) <= 180) {
+    return(student$testritscore[match(min(abs(diff)),abs(diff))])
+  } else {
+    warning('no test score within num_days')
+    return(NA)
+  }
+  
   
 }

--- a/R/nearest_RIT.R
+++ b/R/nearest_RIT.R
@@ -1,26 +1,43 @@
 #' @title find nearest RIT score for a student, by date
 #' 
-#' @description write a description here
+#' @description Given studentid, measurementscale, and a target_date, the function will return the closest RIT score. 
 #' 
 #' @param mapvizieR_obj mapvizieR object
-#' @param studentid target student
-#' @param measurementscale target subject
-#' @param target_date     write a description here
-
+#' @param sid target studentid
+#' @param measurescale target subject
+#' @param target_date date of interest, %Y-%m-%d format
+#' @param foward default is TRUE, set to FALSE if only scores before target_date should be chosen
+#' 
 #' @export
 
 
-nearest_rit <- function(  
+nearest_rit <- function(
   mapvizieR_obj,
-  studentid,
-  measurementscale,
-  target_date
+  sid,
+  measurescale,
+  target_date,
+  forward=TRUE
 ) {
-  #write some code here
+
+  # pull out the cdf
+  cdf <- mapvizieR_obj[['cdf']]
   
-  #pull out the cdf
+  # find the matchings rows
+  if (require(dplyr)) {
+    student <- cdf %>% dplyr::filter(studentid == sid,
+                                     measurementscale == measurescale)
+  } else {
+    student <- subset(cdf, studentid == sid & measurementscale == measurescale)
+  }
+
+  # filter out rows if forward = FALSE
+  if (!forward) {
+    student <- student[student$teststartdate <= as.Date(target_date),]
+  }
+
+  # find closest date and return rit score on that day
+  diff <- as.numeric(as.Date(target_date) - student$teststartdate)
   
-  #find the matchings rows
+  return(student$testritscore[match(min(abs(diff)),abs(diff))])
   
-  #return something sensible
 }

--- a/R/nearest_RIT.R
+++ b/R/nearest_RIT.R
@@ -36,7 +36,7 @@ nearest_rit <- function(
   # find closest date and return rit score on that day
   diff <- as.numeric(as.Date(target_date) - student$teststartdate)
   
-  if (min(abs(diff)) <= 180) {
+  if (min(abs(diff)) <= num_days) {
     return(student$testritscore[match(min(abs(diff)),abs(diff))])
   } else {
     warning('no test score within num_days')

--- a/R/nearest_RIT.R
+++ b/R/nearest_RIT.R
@@ -1,0 +1,26 @@
+#' @title find nearest RIT score for a student, by date
+#' 
+#' @description write a description here
+#' 
+#' @param mapvizieR_obj mapvizieR object
+#' @param studentid target student
+#' @param measurementscale target subject
+#' @param target_date     write a description here
+
+#' @export
+
+
+nearest_rit <- function(  
+  mapvizieR_obj,
+  studentid,
+  measurementscale,
+  target_date
+) {
+  #write some code here
+  
+  #pull out the cdf
+  
+  #find the matchings rows
+  
+  #return something sensible
+}

--- a/R/nearest_RIT.R
+++ b/R/nearest_RIT.R
@@ -21,12 +21,23 @@ nearest_rit <- function(
   forward=TRUE
 ) {
 
+    # check that measurementscale is given / valid
+  if (missing(measurementscale)) {
+    stop('mesaurementscale not given')
+  } else if (!(measurementscale %in% c('General Science','Language Usage','Mathematics','Reading'))) {
+    stop('invalid measurementscale')
+  }
+  
   # pull out the cdf
   cdf <- mapvizieR_obj[['cdf']]
   
   # find the matchings rows
   student <- cdf[(cdf$studentid == studentid & cdf$measurementscale == measurementscale),]
 
+  if (!(studentid %in% cdf$studentid)) {
+    stop('studentid not in mapvizieR cdf object')
+  }
+  
   # filter out rows if forward = FALSE
   if (!forward) {
     student <- student[student$teststartdate <= as.Date(target_date),]

--- a/tests/testthat/test_estimate_RIT.R
+++ b/tests/testthat/test_estimate_RIT.R
@@ -1,61 +1,76 @@
 context("estimate_rit tests")
 
+# mapviz2 in global environment defined:
+# mapviz2 <- mapviz
+# mapviz2[['cdf']] <- filter(mapviz2[['cdf']],studentid=='F08000002',measurementscale=='Mathematics')[1,]
+testing_constants()
+
 test_that("estimate_rit does expected stuff ", {
 
   # test closest
-  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20',method='closest')
+  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-10-20',method='closest')
   expect_equal(samp_val, 209)
   
   # test that forward parameter works
-  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2013-11-30',method='closest',forward=FALSE)
+  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-11-30',method='closest',forward=FALSE)
   expect_equal(samp_val, 209)
   
   # test lm
-  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20',method='lm')
+  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-10-20',method='lm')
   expect_true(is.numeric(samp_val))
   
-  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-9-20',method='lm')
+  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2014-9-20',method='lm')
   expect_true(is.numeric(samp_val))
   
   # test interpolate
-  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20',method='interpolate')
+  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-10-20',method='interpolate')
+  expect_true(is.numeric(samp_val))
+  
+  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-9-12',method='interpolate')
   expect_true(is.numeric(samp_val))
   
   # target_date is a test date
-  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-03-16',method='closest')
+  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2014-03-16',method='closest')
   expect_equal(samp_val,219)
   
   # check when student hasn't taken a test in given measurementscale
-  samp_val <- estimate_rit(mapviz,'F08000002','General Science','2013-10-20',method='closest')
+  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='General Science',target_date='2013-10-20',method='closest')
   expect_true(is.na(samp_val))
   
-  samp_val <- estimate_rit(mapviz,'F08000003','General Science','2013-10-20',method='closest')
+  samp_val <- estimate_rit(mapviz,studentid='F08000003',measurementscale='General Science',target_date='2013-10-20',method='closest')
   expect_true(is.na(samp_val))
   
   # target_date before first test event
-  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2013-1-10',method='interpolate')
+  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-1-10',method='interpolate')
   expect_true(is.na(samp_val))
   
   # target_date after last test event
-  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-5-16',method='interpolate')
+  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2014-5-16',method='interpolate')
   expect_true(is.na(samp_val))
   
   # test that error is returned
-  expect_error(estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20'))
+  expect_error(estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-10-20'))
   
-  expect_error(estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20','logistic'))
+  expect_error(estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-10-20',method='logistic'))
   
-  expect_error(estimate_rit(mapviz,'abcdefg','Mathematics','2013-10-20','closest'))
+  expect_error(estimate_rit(mapviz,studentid='abcdefg',measurementscale='Mathematics',target_date='2013-10-20',method='closest'))
   
   # test num_days
-  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-9-20','closest')
+  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2014-9-20',method='closest')
   expect_true(is.na(samp_val))
   
   # change num_days to include this date
-  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-9-20','closest',num_days=200)
+  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2014-9-20',method='closest',num_days=200)
   expect_equal(samp_val,219)
   
   # measurement scale not given / spelled wrong
-  expect_error(estimate_rit(mapviz,'F08000002','2013-10-20'))
-  expect_error(estimate_rit(mapviz,'F08000002','Mathatacsa','2013-9-20'))
+  expect_error(estimate_rit(mapviz,studentid='F08000002',target_date='2013-10-20'))
+  expect_error(estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathatacsa',target_date='2013-9-20'))
+  
+  # only one test event for measurement scale
+  samp_val <- estimate_rit(mapviz2,studentid='F08000002',measurementscale='Mathematics',target_date='2013-9-20',method='closest')
+  expect_equal(samp_val,209)
+  
+  samp_val <- estimate_rit(mapviz2,studentid='F08000002',measurementscale='Mathematics',target_date='2015-9-20',method='closest')
+  expect_true(is.na(samp_val))
 })

--- a/tests/testthat/test_estimate_RIT.R
+++ b/tests/testthat/test_estimate_RIT.R
@@ -1,0 +1,32 @@
+context("estimate_rit tests")
+
+test_that("estimate_rit does expected stuff ", {
+
+  # test closest
+  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20',method='closest')
+  expect_equal(samp_val, 209)
+  
+  # test that forward parameter works
+  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2013-11-30',method='closest',forward=FALSE)
+  expect_equal(samp_val, 209)
+  
+  # test lm
+  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20',method='lm')
+  expect_true(is.numeric(samp_val))
+  
+  # test interpolate
+  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20',method='interpolate')
+  expect_true(is.numeric(samp_val))
+  
+  # check when student hasn't take test in given measurementscale
+  samp_val <- estimate_rit(mapviz,'F08000002','General Science','2013-10-20',method='closest')
+  expect_true(is.na(samp_val))
+  
+  # target_date before first test event
+  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2013-1-10',method='interpolate')
+  expect_true(is.na(samp_val))
+  
+  # target_date after last test event
+  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-5-16',method='interpolate')
+  expect_true(is.na(samp_val))
+})

--- a/tests/testthat/test_estimate_RIT.R
+++ b/tests/testthat/test_estimate_RIT.R
@@ -14,6 +14,9 @@ test_that("estimate_rit does expected stuff ", {
   samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20',method='lm')
   expect_true(is.numeric(samp_val))
   
+  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-9-20',method='lm')
+  expect_true(is.numeric(samp_val))
+  
   # test interpolate
   samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20',method='interpolate')
   expect_true(is.numeric(samp_val))
@@ -24,6 +27,9 @@ test_that("estimate_rit does expected stuff ", {
   
   # check when student hasn't taken a test in given measurementscale
   samp_val <- estimate_rit(mapviz,'F08000002','General Science','2013-10-20',method='closest')
+  expect_true(is.na(samp_val))
+  
+  samp_val <- estimate_rit(mapviz,'F08000003','General Science','2013-10-20',method='closest')
   expect_true(is.na(samp_val))
   
   # target_date before first test event
@@ -39,6 +45,8 @@ test_that("estimate_rit does expected stuff ", {
   
   expect_error(estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20','logistic'))
   
+  expect_error(estimate_rit(mapviz,'abcdefg','Mathematics','2013-10-20','closest'))
+  
   # test num_days
   samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-9-20','closest')
   expect_true(is.na(samp_val))
@@ -47,4 +55,7 @@ test_that("estimate_rit does expected stuff ", {
   samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-9-20','closest',num_days=200)
   expect_equal(samp_val,219)
   
+  # measurement scale not given / spelled wrong
+  expect_error(estimate_rit(mapviz,'F08000002','2013-10-20'))
+  expect_error(estimate_rit(mapviz,'F08000002','Mathatacsa','2013-9-20'))
 })

--- a/tests/testthat/test_estimate_RIT.R
+++ b/tests/testthat/test_estimate_RIT.R
@@ -18,11 +18,11 @@ test_that("estimate_rit does expected stuff ", {
   samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20',method='interpolate')
   expect_true(is.numeric(samp_val))
   
-  # target_date is an test date
+  # target_date is a test date
   samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-03-16',method='closest')
   expect_equal(samp_val,219)
   
-  # check when student hasn't take test in given measurementscale
+  # check when student hasn't taken a test in given measurementscale
   samp_val <- estimate_rit(mapviz,'F08000002','General Science','2013-10-20',method='closest')
   expect_true(is.na(samp_val))
   
@@ -32,5 +32,14 @@ test_that("estimate_rit does expected stuff ", {
   
   # target_date after last test event
   samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-5-16',method='interpolate')
+  expect_true(is.na(samp_val))
+  
+  # test that error is returned
+  expect_error(estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20'))
+  
+  expect_error(estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20','logistic'))
+  
+  # test num_days
+  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2018-10-20','closest')
   expect_true(is.na(samp_val))
 })

--- a/tests/testthat/test_estimate_RIT.R
+++ b/tests/testthat/test_estimate_RIT.R
@@ -40,6 +40,11 @@ test_that("estimate_rit does expected stuff ", {
   expect_error(estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20','logistic'))
   
   # test num_days
-  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2018-10-20','closest')
+  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-9-20','closest')
   expect_true(is.na(samp_val))
+  
+  # change num_days to include this date
+  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-9-20','closest',num_days=200)
+  expect_equal(samp_val,219)
+  
 })

--- a/tests/testthat/test_estimate_RIT.R
+++ b/tests/testthat/test_estimate_RIT.R
@@ -1,76 +1,121 @@
 context("estimate_rit tests")
 
 # mapviz2 in global environment defined:
-# mapviz2 <- mapviz
-# mapviz2[['cdf']] <- filter(mapviz2[['cdf']],studentid=='F08000002',measurementscale=='Mathematics')[1,]
 testing_constants()
 
 test_that("estimate_rit does expected stuff ", {
 
   # test closest
-  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-10-20',method='closest')
-  expect_equal(samp_val, 209)
+  samp_val <- estimate_rit(mapviz, studentid = 'F08000002', 
+                           measurementscale = 'Mathematics', target_date = '2013-10-20', 
+                           method = 'closest')
+  expect_equal(samp_val, 209, tolerance = .01)
   
   # test that forward parameter works
-  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-11-30',method='closest',forward=FALSE)
-  expect_equal(samp_val, 209)
+  samp_val <- estimate_rit(mapviz, studentid = 'F08000002', 
+                           measurementscale = 'Mathematics', target_date = '2013-11-30', 
+                           method = 'closest', forward = FALSE)
+  expect_equal(samp_val, 209, tolerance = .01)
   
   # test lm
-  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-10-20',method='lm')
+  samp_val <- estimate_rit(mapviz, studentid = 'F08000002', 
+                           measurementscale = 'Mathematics', target_date = '2013-10-20',
+                           method = 'lm')
   expect_true(is.numeric(samp_val))
   
-  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2014-9-20',method='lm')
+  samp_val <- estimate_rit(mapviz, studentid = 'F08000002', 
+                           measurementscale = 'Mathematics',
+                           target_date = '2014-9-20', method = 'lm')
   expect_true(is.numeric(samp_val))
   
   # test interpolate
-  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-10-20',method='interpolate')
+  samp_val <- estimate_rit(mapviz, studentid = 'F08000002',
+                           measurementscale = 'Mathematics',
+                           target_date = '2013-10-20',
+                           method = 'interpolate')
   expect_true(is.numeric(samp_val))
   
-  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-9-12',method='interpolate')
+  samp_val <- estimate_rit(mapviz, studentid = 'F08000002',
+                           measurementscale = 'Mathematics', 
+                           target_date = '2013-9-12', method = 'interpolate')
   expect_true(is.numeric(samp_val))
   
   # target_date is a test date
-  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2014-03-16',method='closest')
-  expect_equal(samp_val,219)
+  samp_val <- estimate_rit(mapviz, studentid = 'F08000002',
+                           measurementscale = 'Mathematics',
+                           target_date = '2014-03-16', method = 'closest')
+  expect_equal(samp_val, 219, tolerance = .01)
   
   # check when student hasn't taken a test in given measurementscale
-  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='General Science',target_date='2013-10-20',method='closest')
+  samp_val <- estimate_rit(mapviz, studentid = 'F08000002',
+                           measurementscale = 'General Science',
+                           target_date = '2013-10-20', method = 'closest')
   expect_true(is.na(samp_val))
   
-  samp_val <- estimate_rit(mapviz,studentid='F08000003',measurementscale='General Science',target_date='2013-10-20',method='closest')
+  samp_val <- estimate_rit(mapviz, studentid = 'F08000003', 
+                           measurementscale = 'General Science',
+                           target_date = '2013-10-20', method = 'closest')
   expect_true(is.na(samp_val))
   
   # target_date before first test event
-  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-1-10',method='interpolate')
+  samp_val <- estimate_rit(mapviz, studentid = 'F08000002',
+                           measurementscale = 'Mathematics',
+                           target_date = '2013-1-10', method = 'interpolate')
   expect_true(is.na(samp_val))
   
   # target_date after last test event
-  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2014-5-16',method='interpolate')
+  samp_val <- estimate_rit(mapviz,studentid = 'F08000002', 
+                           measurementscale = 'Mathematics', 
+                           target_date = '2014-5-16',
+                           method = 'interpolate')
   expect_true(is.na(samp_val))
   
   # test that error is returned
-  expect_error(estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-10-20'))
+  expect_error(
+    estimate_rit(mapviz, studentid = 'F08000002', measurementscale = 'Mathematics', 
+                 target_date = '2013-10-20')
+  )
   
-  expect_error(estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-10-20',method='logistic'))
+  expect_error(
+    estimate_rit(mapviz, studentid = 'F08000002', measurementscale = 'Mathematics',
+                 target_date = '2013-10-20', method = 'logistic')
+  )
   
-  expect_error(estimate_rit(mapviz,studentid='abcdefg',measurementscale='Mathematics',target_date='2013-10-20',method='closest'))
+  expect_error(
+    estimate_rit(mapviz, studentid = 'abcdefg', measurementscale = 'Mathematics', 
+                 target_date = '2013-10-20', method = 'closest')
+  )
   
   # test num_days
-  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2014-9-20',method='closest')
+  samp_val <- estimate_rit(mapviz, studentid = 'F08000002', 
+                           measurementscale = 'Mathematics', 
+                           target_date = '2014-9-20', method = 'closest')
   expect_true(is.na(samp_val))
   
   # change num_days to include this date
-  samp_val <- estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2014-9-20',method='closest',num_days=200)
-  expect_equal(samp_val,219)
+  samp_val <- estimate_rit(mapviz, studentid = 'F08000002',measurementscale = 'Mathematics',target_date = '2014-9-20',method = 'closest',num_days = 200)
+  expect_equal(samp_val, 219, tolerance = .01)
   
   # measurement scale not given / spelled wrong
-  expect_error(estimate_rit(mapviz,studentid='F08000002',target_date='2013-10-20'))
-  expect_error(estimate_rit(mapviz,studentid='F08000002',measurementscale='Mathatacsa',target_date='2013-9-20'))
+  expect_error(estimate_rit(mapviz, studentid = 'F08000002', target_date = '2013-10-20'))
+  expect_error(
+    estimate_rit(mapviz,studentid = 'F08000002', measurementscale = 'Mathatacsa', 
+                 target_date = '2013-9-20')
+    )
   
   # only one test event for measurement scale
-  samp_val <- estimate_rit(mapviz2,studentid='F08000002',measurementscale='Mathematics',target_date='2013-9-20',method='closest')
-  expect_equal(samp_val,209)
+  # filtered mapviz object to test for errors
+  mapviz2 <- mapviz
+  mapviz2[['cdf']] <-  dplyr::filter(mapviz2[['cdf']], studentid == 'F08000002', 
+                                     measurementscale == 'Mathematics')[1,]
+
+  samp_val <- estimate_rit(mapviz2, studentid = 'F08000002', 
+                           measurementscale = 'Mathematics', target_date = '2013-9-20',
+                           method = 'closest')
+  expect_equal(samp_val, 209, tolerance = .01)
   
-  samp_val <- estimate_rit(mapviz2,studentid='F08000002',measurementscale='Mathematics',target_date='2015-9-20',method='closest')
+  samp_val <- estimate_rit(mapviz2, studentid = 'F08000002', 
+                           measurementscale = 'Mathematics', target_date = '2015-9-20',
+                           method = 'closest')
   expect_true(is.na(samp_val))
 })

--- a/tests/testthat/test_estimate_RIT.R
+++ b/tests/testthat/test_estimate_RIT.R
@@ -18,6 +18,10 @@ test_that("estimate_rit does expected stuff ", {
   samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2013-10-20',method='interpolate')
   expect_true(is.numeric(samp_val))
   
+  # target_date is an test date
+  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-03-16',method='closest')
+  expect_equal(samp_val,219)
+  
   # check when student hasn't take test in given measurementscale
   samp_val <- estimate_rit(mapviz,'F08000002','General Science','2013-10-20',method='closest')
   expect_true(is.na(samp_val))

--- a/tests/testthat/test_nearest_RIT.R
+++ b/tests/testthat/test_nearest_RIT.R
@@ -3,40 +3,40 @@ context("nearest_rit tests")
 test_that("nearest_rit does expected stuff ", {
 
   # test that it works to find closest
-  samp_val <- nearest_rit(mapviz,'F08000002','Mathematics','2013-10-20')
+  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-10-20')
   expect_equal(samp_val, 209)
   
-  samp_val <- nearest_rit(mapviz,'F08000002','Reading','2013-10-20')
+  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Reading',target_date='2013-10-20')
   expect_equal(samp_val, 217)
   
-  samp_val <- nearest_rit(mapviz,'F08000002','Language Usage','2013-10-20')
+  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Language Usage',target_date='2013-10-20')
   expect_equal(samp_val, 215)
   
-  samp_val <- nearest_rit(mapviz,'F08000006','General Science','2013-10-20')
+  samp_val <- nearest_rit(mapviz,studentid='F08000006',measurementscale='General Science',target_date='2013-10-20')
   expect_equal(samp_val, 194)
   
   # test that forward parameter does its job
-  samp_val <- nearest_rit(mapviz,'F08000002','Mathematics','2013-11-30',forward=FALSE)
+  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-11-30',forward=FALSE)
   expect_equal(samp_val, 209)
   
-  samp_val <- nearest_rit(mapviz,'F08000002','Reading','2013-11-30',forward=FALSE)
+  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Reading',target_date='2013-11-30',forward=FALSE)
   expect_equal(samp_val, 217)
   
-  samp_val <- nearest_rit(mapviz,'F08000002','Language Usage','2013-11-30',forward=FALSE)
+  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Language Usage',target_date='2013-11-30',forward=FALSE)
   expect_equal(samp_val, 215)
   
-  samp_val <- nearest_rit(mapviz,'F08000006','General Science','2013-11-30',forward=FALSE)
+  samp_val <- nearest_rit(mapviz,studentid='F08000006',measurementscale='General Science',target_date='2013-11-30',forward=FALSE)
   expect_equal(samp_val, 194)
   
   # test num_days
-  samp_val <- nearest_rit(mapviz,'F08000002','Mathematics','2014-9-20')
+  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2014-9-20')
   expect_true(is.na(samp_val))
   
-  samp_val <- nearest_rit(mapviz,'F08000002','Mathematics','2014-9-20',num_days=200)
+  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2014-9-20',num_days=200)
   expect_equal(samp_val,219)
   
   # test errors
-  expect_error(nearest_rit(mapviz,'F08000002','2013-10-20'))
-  expect_error(nearest_rit(mapviz,'F08000002','Mathatacsa','2013-9-20'))
-  expect_error(nearest_rit(mapviz,'abcdefg','Mathematics','2013-10-20'))
+  expect_error(nearest_rit(mapviz,studentid='F08000002',target_date='2013-10-20'))
+  expect_error(nearest_rit(mapviz,studentid='F08000002',measurementscale='Mathatacsa',target_date='2013-9-20'))
+  expect_error(nearest_rit(mapviz,studentid='abcdefg',measurementscale='Mathematics',target_date='2013-10-20'))
 })

--- a/tests/testthat/test_nearest_RIT.R
+++ b/tests/testthat/test_nearest_RIT.R
@@ -1,0 +1,15 @@
+context("nearest_rit tests")
+
+#make sure that constants used below exist
+testing_constants()
+
+
+test_that("nearest_rit does expected stuff ", {
+
+  #psuedocode
+  #samp_val <- nearest_rit(param, param, param)
+  #expect_equal(samp_val, 220)
+  
+  expect_equal(1+1,  2)
+
+})

--- a/tests/testthat/test_nearest_RIT.R
+++ b/tests/testthat/test_nearest_RIT.R
@@ -6,40 +6,48 @@ testing_constants()
 test_that("nearest_rit does expected stuff ", {
 
   # test that it works to find closest
-  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-10-20')
+  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Mathematics', 
+    target_date='2013-10-20')
   expect_equal(samp_val, 209)
   
-  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Reading',target_date='2013-10-20')
+  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Reading', 
+    target_date='2013-10-20')
   expect_equal(samp_val, 217)
   
-  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Language Usage',target_date='2013-10-20')
+  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Language Usage', 
+    target_date='2013-10-20')
   expect_equal(samp_val, 215)
   
-  samp_val <- nearest_rit(mapviz,studentid='F08000006',measurementscale='General Science',target_date='2013-10-20')
+  samp_val <- nearest_rit(mapviz, studentid='F08000006', measurementscale='General Science', 
+    target_date='2013-10-20')
   expect_equal(samp_val, 194)
   
   # test that forward parameter does its job
-  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2013-11-30',forward=FALSE)
+  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Mathematics',
+    target_date='2013-11-30', forward=FALSE)
   expect_equal(samp_val, 209)
   
-  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Reading',target_date='2013-11-30',forward=FALSE)
+  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Reading', 
+    target_date='2013-11-30', forward=FALSE)
   expect_equal(samp_val, 217)
   
-  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Language Usage',target_date='2013-11-30',forward=FALSE)
+  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Language Usage', 
+    target_date='2013-11-30', forward=FALSE)
   expect_equal(samp_val, 215)
   
-  samp_val <- nearest_rit(mapviz,studentid='F08000006',measurementscale='General Science',target_date='2013-11-30',forward=FALSE)
+  samp_val <- nearest_rit(mapviz, studentid='F08000006', measurementscale='General Science', 
+    target_date='2013-11-30', forward=FALSE)
   expect_equal(samp_val, 194)
   
   # test num_days
-  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2014-9-20')
+  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Mathematics',target_date='2014-9-20')
   expect_true(is.na(samp_val))
   
-  samp_val <- nearest_rit(mapviz,studentid='F08000002',measurementscale='Mathematics',target_date='2014-9-20',num_days=200)
+  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Mathematics',target_date='2014-9-20',num_days=200)
   expect_equal(samp_val,219)
   
   # test errors
-  expect_error(nearest_rit(mapviz,studentid='F08000002',target_date='2013-10-20'))
-  expect_error(nearest_rit(mapviz,studentid='F08000002',measurementscale='Mathatacsa',target_date='2013-9-20'))
-  expect_error(nearest_rit(mapviz,studentid='abcdefg',measurementscale='Mathematics',target_date='2013-10-20'))
+  expect_error(nearest_rit(mapviz, studentid='F08000002', target_date='2013-10-20'))
+  expect_error(nearest_rit(mapviz, studentid='F08000002', measurementscale='Mathatacsa',target_date='2013-9-20'))
+  expect_error(nearest_rit(mapviz, studentid='abcdefg', measurementscale='Mathematics',target_date='2013-10-20'))
 })

--- a/tests/testthat/test_nearest_RIT.R
+++ b/tests/testthat/test_nearest_RIT.R
@@ -6,48 +6,52 @@ testing_constants()
 test_that("nearest_rit does expected stuff ", {
 
   # test that it works to find closest
-  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Mathematics', 
-    target_date='2013-10-20')
+  samp_val <- nearest_rit(mapviz, studentid = 'F08000002', measurementscale = 'Mathematics', 
+    target_date = '2013-10-20')
   expect_equal(samp_val, 209)
   
-  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Reading', 
-    target_date='2013-10-20')
+  samp_val <- nearest_rit(mapviz, studentid = 'F08000002', measurementscale = 'Reading', 
+    target_date = '2013-10-20')
   expect_equal(samp_val, 217)
   
-  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Language Usage', 
-    target_date='2013-10-20')
+  samp_val <- nearest_rit(mapviz, studentid = 'F08000002', measurementscale = 'Language Usage', 
+    target_date = '2013-10-20')
   expect_equal(samp_val, 215)
   
-  samp_val <- nearest_rit(mapviz, studentid='F08000006', measurementscale='General Science', 
-    target_date='2013-10-20')
+  samp_val <- nearest_rit(mapviz, studentid = 'F08000006', measurementscale = 'General Science', 
+    target_date = '2013-10-20')
   expect_equal(samp_val, 194)
   
   # test that forward parameter does its job
-  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Mathematics',
-    target_date='2013-11-30', forward=FALSE)
+  samp_val <- nearest_rit(mapviz, studentid = 'F08000002', measurementscale = 'Mathematics',
+    target_date = '2013-11-30', forward = FALSE)
   expect_equal(samp_val, 209)
   
-  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Reading', 
-    target_date='2013-11-30', forward=FALSE)
+  samp_val <- nearest_rit(mapviz, studentid = 'F08000002', measurementscale = 'Reading', 
+    target_date = '2013-11-30', forward = FALSE)
   expect_equal(samp_val, 217)
   
-  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Language Usage', 
-    target_date='2013-11-30', forward=FALSE)
+  samp_val <- nearest_rit(mapviz, studentid = 'F08000002', measurementscale = 'Language Usage', 
+    target_date = '2013-11-30', forward = FALSE)
   expect_equal(samp_val, 215)
   
-  samp_val <- nearest_rit(mapviz, studentid='F08000006', measurementscale='General Science', 
-    target_date='2013-11-30', forward=FALSE)
+  samp_val <- nearest_rit(mapviz, studentid = 'F08000006', measurementscale = 'General Science', 
+    target_date = '2013-11-30', forward = FALSE)
   expect_equal(samp_val, 194)
   
   # test num_days
-  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Mathematics',target_date='2014-9-20')
+  samp_val <- nearest_rit(mapviz, studentid = 'F08000002', 
+                          measurementscale = 'Mathematics',target_date = '2014-9-20')
   expect_true(is.na(samp_val))
   
-  samp_val <- nearest_rit(mapviz, studentid='F08000002', measurementscale='Mathematics',target_date='2014-9-20',num_days=200)
+  samp_val <- nearest_rit(mapviz, studentid = 'F08000002', measurementscale = 'Mathematics', 
+                          target_date = '2014-9-20',num_days = 200)
   expect_equal(samp_val,219)
   
   # test errors
-  expect_error(nearest_rit(mapviz, studentid='F08000002', target_date='2013-10-20'))
-  expect_error(nearest_rit(mapviz, studentid='F08000002', measurementscale='Mathatacsa',target_date='2013-9-20'))
-  expect_error(nearest_rit(mapviz, studentid='abcdefg', measurementscale='Mathematics',target_date='2013-10-20'))
+  expect_error(nearest_rit(mapviz, studentid = 'F08000002', target_date = '2013-10-20'))
+  expect_error(nearest_rit(mapviz, studentid = 'F08000002', measurementscale = 'Mathatacsa', 
+                           target_date = '2013-9-20'))
+  expect_error(nearest_rit(mapviz, studentid = 'abcdefg', measurementscale = 'Mathematics',
+                           target_date = '2013-10-20'))
 })

--- a/tests/testthat/test_nearest_RIT.R
+++ b/tests/testthat/test_nearest_RIT.R
@@ -1,9 +1,5 @@
 context("nearest_rit tests")
 
-#make sure that constants used below exist
-# testing_constants()
-
-
 test_that("nearest_rit does expected stuff ", {
 
   # test that it works to find closest
@@ -33,9 +29,14 @@ test_that("nearest_rit does expected stuff ", {
   expect_equal(samp_val, 194)
   
   # test num_days
-  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-9-20','closest')
+  samp_val <- nearest_rit(mapviz,'F08000002','Mathematics','2014-9-20')
   expect_true(is.na(samp_val))
   
-  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-9-20','closest',num_days=200)
+  samp_val <- nearest_rit(mapviz,'F08000002','Mathematics','2014-9-20',num_days=200)
   expect_equal(samp_val,219)
+  
+  # test errors
+  expect_error(nearest_rit(mapviz,'F08000002','2013-10-20'))
+  expect_error(nearest_rit(mapviz,'F08000002','Mathatacsa','2013-9-20'))
+  expect_error(nearest_rit(mapviz,'abcdefg','Mathematics','2013-10-20'))
 })

--- a/tests/testthat/test_nearest_RIT.R
+++ b/tests/testthat/test_nearest_RIT.R
@@ -33,6 +33,9 @@ test_that("nearest_rit does expected stuff ", {
   expect_equal(samp_val, 194)
   
   # test num_days
-  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2018-10-20','closest')
+  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-9-20','closest')
   expect_true(is.na(samp_val))
+  
+  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2014-9-20','closest',num_days=200)
+  expect_equal(samp_val,219)
 })

--- a/tests/testthat/test_nearest_RIT.R
+++ b/tests/testthat/test_nearest_RIT.R
@@ -1,7 +1,7 @@
 context("nearest_rit tests")
 
 #make sure that constants used below exist
-# testing_constants()
+testing_constants()
 
 
 test_that("nearest_rit does expected stuff ", {

--- a/tests/testthat/test_nearest_RIT.R
+++ b/tests/testthat/test_nearest_RIT.R
@@ -1,15 +1,34 @@
 context("nearest_rit tests")
 
 #make sure that constants used below exist
-testing_constants()
+# testing_constants()
 
 
 test_that("nearest_rit does expected stuff ", {
 
-  #psuedocode
-  #samp_val <- nearest_rit(param, param, param)
-  #expect_equal(samp_val, 220)
+  # test that it works to find closest
+  samp_val <- nearest_rit(mapviz,'F08000002','Mathematics','2013-10-20')
+  expect_equal(samp_val, 209)
   
-  expect_equal(1+1,  2)
-
+  samp_val <- nearest_rit(mapviz,'F08000002','Reading','2013-10-20')
+  expect_equal(samp_val, 217)
+  
+  samp_val <- nearest_rit(mapviz,'F08000002','Language Usage','2013-10-20')
+  expect_equal(samp_val, 215)
+  
+  samp_val <- nearest_rit(mapviz,'F08000006','General Science','2013-10-20')
+  expect_equal(samp_val, 194)
+  
+  # test that forward parameter does its job
+  samp_val <- nearest_rit(mapviz,'F08000002','Mathematics','2013-11-30',forward=FALSE)
+  expect_equal(samp_val, 209)
+  
+  samp_val <- nearest_rit(mapviz,'F08000002','Reading','2013-11-30',forward=FALSE)
+  expect_equal(samp_val, 217)
+  
+  samp_val <- nearest_rit(mapviz,'F08000002','Language Usage','2013-11-30',forward=FALSE)
+  expect_equal(samp_val, 215)
+  
+  samp_val <- nearest_rit(mapviz,'F08000006','General Science','2013-11-30',forward=FALSE)
+  expect_equal(samp_val, 194)
 })

--- a/tests/testthat/test_nearest_RIT.R
+++ b/tests/testthat/test_nearest_RIT.R
@@ -31,4 +31,8 @@ test_that("nearest_rit does expected stuff ", {
   
   samp_val <- nearest_rit(mapviz,'F08000006','General Science','2013-11-30',forward=FALSE)
   expect_equal(samp_val, 194)
+  
+  # test num_days
+  samp_val <- estimate_rit(mapviz,'F08000002','Mathematics','2018-10-20','closest')
+  expect_true(is.na(samp_val))
 })


### PR DESCRIPTION
estimate_RIT.R contains function to estimate a student's RIT score given a mapvizieR object, studentid, measurementscale, target date, and method. The first method is closest by date and the user can choose whether only scores before the target date are used using the forward parameter. The second method is a linear regression using all test scores. The final method is interpolation using the two scores that contain the target date. test_estimate_rit.R contains tests that will return particular scores, a numeric value, or an NA with a message. 

I think the functionality is there, but it may not be the most efficient methodology. Any thoughts on code would be appreciated.
