### PR TITLE
patch - use end_date for cgp calcs

### DIFF
--- a/R/quealy_subgroups.R
+++ b/R/quealy_subgroups.R
@@ -98,7 +98,7 @@ quealy_subgroups <- function(
   #2| INTERNAL FUNCTIONS
   group_summary <- function(grouped_df, subgroup) {
     
-    approximate_grade <- round(mean(grouped_df$start_grade, na.rm=TRUE), 0)  
+    approximate_grade <- round(mean(grouped_df$end_grade, na.rm=TRUE), 0)  
     
     df <- grouped_df %>%
     summarize(
@@ -107,7 +107,7 @@ quealy_subgroups <- function(
       rit_change = mean(rit_growth, na.rm=TRUE),
       start_npr = mean(start_consistent_percentile, na.rm=TRUE),
       end_npr = mean(end_consistent_percentile, na.rm=TRUE),
-      npr_change = mean(start_consistent_percentile - end_consistent_percentile, na.rm=TRUE),
+      npr_change = mean(end_consistent_percentile - start_consistent_percentile, na.rm=TRUE),
       n = n()
     ) %>%       
     #add cgp
@@ -296,6 +296,7 @@ quealy_subgroups <- function(
   #all students
   this_growth$all_students <- 'All Students'
   total_change <- group_summary(dplyr::group_by(this_growth, all_students), 'all_students')
+  
   p_all <- facet_one_subgroup(
     df = total_change, 
     subgroup = 'All Students',

--- a/man/calc_cgp.Rd
+++ b/man/calc_cgp.Rd
@@ -22,7 +22,7 @@ calc_cgp(measurementscale, grade, growth_window, baseline_avg_rit = NA,
 
 \item{ending_avg_rit}{the baseline mean rit for the group of students}
 
-\item{ending_avg_npr}{the baseleine mean percentile rank for the group of students}
+\item{ending_avg_npr}{the baseline mean percentile rank for the group of students}
 
 \item{tolerance}{NWEA has published empirical lookup tables for growth.  these tables cover
 the middle of the distribution, meaning that data for most cohorts can be found in the table.

--- a/man/two_pager.Rd
+++ b/man/two_pager.Rd
@@ -28,8 +28,6 @@ two_pager(mapvizieR_obj, studentids, measurementscale, start_fws,
 \item{title_text}{what is this report called?}
 
 \item{...}{additional arguments}
-
-\item{detail_academic_year}{don't mask any data for this academic year}
 }
 \value{
 prints a ggplot object


### PR DESCRIPTION
@chrishaid hotfix here - was using `start_grade` for cgp calcs, but tables are based on `end_grade`...
