### PR TITLE
function to filter a mv object

### DIFF
--- a/R/mv_filter.R
+++ b/R/mv_filter.R
@@ -1,0 +1,45 @@
+#' @title filter mapvizieR object
+#'
+#' @description filter a mapvizieR object by academic year, or any variable in the roster.
+#' 
+#' @param mapvizieR_obj mapvizieR object
+#' @param 
+#'
+#' @return 
+#' 
+#' @export
+
+mv_filter <- function(mapvizieR_obj, cdf_filter=NA, roster_filter=NA) {
+  
+  #must pass some kind of filter
+  if (!is.language(cdf_filter) & !is.language(roster_filter)) {
+    stop('at least one type of filter needed (cdf or roster)')
+  }
+  
+  mapviz <- mapvizieR_obj
+  
+  #cdf fields
+  if (typeof(cdf_filter) == 'language') {
+    mapviz[['cdf']] <- mapviz[['cdf']] %>%
+      dplyr::filter_(
+        cdf_filter
+      )
+  }
+
+  #roster fields
+  if (typeof(roster_filter) == 'language') {
+    #filter the roster
+    mapviz[['roster']] <- mapviz[['roster']] %>%
+      dplyr::filter_(
+        roster_filter
+      )
+    
+    target_stu <- mapviz[['roster']]$studentid
+    
+    #then use those studentids to filter the cdf
+    mapviz[['cdf']] <-  mapviz[['cdf']] %>% 
+      dplyr::filter(studentid %in% target_stu) 
+  }
+  
+  return(mapviz)
+}

--- a/tests/testthat/test_mv_filter.R
+++ b/tests/testthat/test_mv_filter.R
@@ -1,0 +1,75 @@
+context("mapvizier filter tests")
+
+#make sure that constants used below exist
+testing_constants()
+
+
+test_that("mapvizier filters cdf year", {
+  filter_ex <- mv_filter(
+    mapvizieR_obj = mapviz, 
+    cdf_filter = quote(map_year_academic == 2013)
+  )
+  
+  expect_equal(nrow(filter_ex[['cdf']]), 6558)
+
+  filter_ex <- mv_filter(
+    mapvizieR_obj = mapviz, 
+    cdf_filter = quote(map_year_academic == 2012)
+  )
+  
+  expect_equal(nrow(filter_ex[['cdf']]), 1993)
+})
+  
+
+test_that("mapvizier filters cdf grade", {
+  filter_ex <- mv_filter(
+    mapvizieR_obj = mapviz, 
+    cdf_filter = quote(grade == 6)
+  )
+  
+  expect_equal(nrow(filter_ex[['cdf']]), 1185)
+})
+  
+
+test_that("mapvizier filters cdf year and grade", {
+  filter_ex <- mv_filter(
+    mapvizieR_obj = mapviz, 
+    cdf_filter = quote(map_year_academic == 2013 & grade == 6)
+  )
+  
+  expect_equal(nrow(filter_ex[['cdf']]), 837)
+})
+
+
+
+test_that("mapvizier filters roster one category", {
+  filter_ex <- mv_filter(
+    mapvizieR_obj = mapviz, 
+    roster_filter = quote(schoolname == "Three Sisters Elementary School")
+  )
+  
+  expect_equal(nrow(filter_ex[['cdf']]), 1883)
+})
+
+
+test_that("mapvizier filters roster two categories", {
+  #students who were ever in the 3rd grade (kind of weird - remember that roster has *all* enrollments)
+  filter_ex <- mv_filter(
+    mapvizieR_obj = mapviz, 
+    roster_filter = quote(schoolname == "Three Sisters Elementary School" &  grade == 3)
+  )
+  
+  expect_equal(nrow(filter_ex[['cdf']]), 656)
+})
+
+
+test_that("mapvizier filters cdf AND roster", {
+  #students who were ever in the 3rd grade (kind of weird - remember that roster has *all* enrollments)
+  filter_ex <- mv_filter(
+    mapvizieR_obj = mapviz, 
+    cdf_filter = quote(map_year_academic == 2013),
+    roster_filter = quote(schoolname == "Three Sisters Elementary School")
+  )
+  
+  expect_equal(nrow(filter_ex[['cdf']]), 1401)
+})


### PR DESCRIPTION
@chrishaid you are supervising :baby: :baby: in :european_post_office: so presumably you are offline, but this is a function that lets you filter a mapvizier object relatively easily.

intended use would be

```
THRIVE_gr_hr_math <- report_dispatcher(
  mapvizieR_obj = mv_filter(thrive_mv, roster_filter=quote(map_year_academic == 2014 & school =='THRIVE')),
  cut_list = cut_list,
  call_list = call_list,
  func_to_call = "quealy_subgroups",
  arg_list = list(
   'measurementscale' = 'Mathematics',
   'subgroup_cols' = c('hist_hr', 'gender', 'sped'),
   'pretty_names' = c('Class', 'Gender', 'IEP'),
   'start_fws' = 'Spring',
   'start_academic_year' = 2013,
   'end_fws' = 'Spring',
   'end_academic_year' =  2014,
   'report_title' = quote(
     paste0(measurementscale, ' | ', depth_string, ' (', start_fws, '-', end_fws, ')')
    )
  )
)
```

i kind of need this so I might go ahead and merge?  but would love eyes on this code.
