### PR TITLE
Scaffold fix

### DIFF
--- a/R/growth_df_prep.R
+++ b/R/growth_df_prep.R
@@ -109,20 +109,35 @@ student_scaffold <- function(
   end <- simple[simple$fallwinterspring==end_season, ]
 
   #define target columns now, in case we need to step out
-  target_cols <- c("studentid", "measurementscale", "end_schoolname", "end_grade_level_season",
-    "end_grade", "growth_window", "complete_obsv", "match_status",
-    "start_testid", "start_map_year_academic", "start_fallwinterspring",
-    "start_grade", "start_grade_level_season", "start_schoolname",
-    "end_testid", "end_map_year_academic", "end_fallwinterspring"
+  
+  target_cols_list = list(
+    studentid = character(), 
+    measurementscale = character(), 
+    end_schoolname = character(), 
+    end_grade_level_season = double(),
+    end_grade = integer(), 
+    growth_window = character(), 
+    complete_obsv = logical(), 
+    match_status = character(),
+    start_testid = integer(), 
+    start_map_year_academic=integer(), 
+    start_fallwinterspring = character(),
+    start_grade = integer(), 
+    start_grade_level_season = double(), 
+    start_schoolname = character(),
+    end_testid = integer(), 
+    end_map_year_academic = integer(), 
+    end_fallwinterspring = character()
   )
-
-  empty <- data.frame(
-    matrix(vector(), 0, length(target_cols), dimnames=list(c(), target_cols)),
-    stringsAsFactors=F
-  )
+  
+  # Character vector of target column names
+  target_cols <- names(target_cols_list)
+  
+  # empty data.frame
+  empty <- dplyr::as_data_frame(target_cols_list) 
 
   #if there's no data, don't worry about matching; just return a zero row df
-  if (nrow(start) == 0 | nrow(end) == 0) {
+  if (nrow(start) == 0) {
     return(empty)
   }
 
@@ -250,11 +265,14 @@ scores_by_testid <- function(testid, processed_cdf, start_or_end) {
 #' @param processed_cdf conforming mapvizieR processed cdf
 
 build_growth_scaffolds <- function(processed_cdf){
-  f2s <- student_scaffold(processed_cdf, 'Fall', 'Spring', 0)
   f2w <- student_scaffold(processed_cdf, 'Fall', 'Winter', 0)
-  w2s <- student_scaffold(processed_cdf, 'Winter', 'Spring', 0)
+  f2s <- student_scaffold(processed_cdf, 'Fall', 'Spring', 0)
+  f2f <- student_scaffold(processed_cdf, 'Fall', 'Fall', 1)
   s2s <- student_scaffold(processed_cdf, 'Spring', 'Spring', 1)
-  scaffolds <- rbind(f2s, f2w, w2s, s2s)
+  w2s <- student_scaffold(processed_cdf, 'Winter', 'Spring', 0)
+  w2w <- student_scaffold(processed_cdf, 'Winter', 'Winter', 1)
+  
+  scaffolds <- rbind(f2w, f2s,f2f, s2s, w2s, w2w)
 
   return(scaffolds)
 }

--- a/tests/testthat/test_growth_df_prep.R
+++ b/tests/testthat/test_growth_df_prep.R
@@ -64,9 +64,9 @@ test_that("scores_by_testid correctly looks up test events", {
 test_that("generate_growth_df builds scaffold and finds growth scores", {
   
   growth_df <- generate_growth_dfs(processed_cdf)$headline
-  expect_equal(nrow(growth_df), 17010)
-  expect_equal(sum(as.numeric(growth_df$start_testritscore), na.rm=TRUE), 2344192)
-  expect_equal(sum(as.numeric(growth_df$end_testritscore), na.rm=TRUE), 3239190)
+  expect_equal(nrow(growth_df), 25754)
+  expect_equal(sum(as.numeric(growth_df$start_testritscore), na.rm=TRUE), 3295979)
+  expect_equal(sum(as.numeric(growth_df$end_testritscore), na.rm=TRUE), 4190977)
   
 })
 
@@ -74,10 +74,10 @@ test_that("generate_growth_df builds scaffold and finds growth scores", {
 
 test_that("build_growth_scaffolds returns expected output on sample data", {
   scaffold <- build_growth_scaffolds(processed_cdf)
-  expect_equal(nrow(scaffold), 17010)
+  expect_equal(nrow(scaffold), 25754)
   expect_equal(
     round(sum(as.numeric(scaffold$start_grade_level_season), na.rm=T),1), 
-    69667.4
+    97731.6
   )
   expect_equal(
     sum(as.numeric(scaffold$end_testid), na.rm=T) - 
@@ -92,12 +92,12 @@ test_that("growth_testid_lookup behaves as expected", {
     scaffold <- build_growth_scaffolds(processed_cdf)
     score_matched <- growth_testid_lookup(scaffold, processed_cdf)
   
-    expect_equal(nrow(score_matched), 17010)
+    expect_equal(nrow(score_matched), 25754)
     expect_equal(ncol(score_matched), 49)
     expect_equal(sum(as.numeric(score_matched$start_testritscore), na.rm=T), 
-      2344192)
+                 3295979)
     expect_equal(sum(as.numeric(score_matched$end_testritscore), na.rm=T),
-      3239190)
+                 4190977)
 })
 
 
@@ -109,13 +109,13 @@ test_that("growth_norm_lookup find norm data", {
     score_matched, processed_cdf, norms_long, FALSE
   )
   
-  expect_equal(nrow(norm_matched), 17010)
+  expect_equal(nrow(norm_matched), 25754)
   expect_equal(ncol(norm_matched), 52)
   expect_equal(
     as.character(summary(norm_matched)[, 'typical_growth'][3]), 
-    "Median : 2.499  " 
+    "Median : 2.762  " 
   )
-  expect_equal(sum(norm_matched$reported_growth, na.rm=T), 35617)
+  expect_equal(sum(norm_matched$reported_growth, na.rm=T), 53164)
 })
 
 
@@ -128,14 +128,14 @@ test_that("calc_rit_growth_metrics properly calculates growth metrics", {
   
   with_rit_metrics <- calc_rit_growth_metrics(norm_matched)
   
-  expect_equal(nrow(with_rit_metrics), 17010)
+  expect_equal(nrow(with_rit_metrics), 25754)
   expect_equal(ncol(with_rit_metrics), 57)
   expect_equal(median(with_rit_metrics$rit_growth,na.rm = T),3)
   expect_equal(median(with_rit_metrics$change_testpercentile,na.rm = T),1)
   expect_equal(median(with_rit_metrics$cgi,na.rm = T), 0.1155872,  
                tolerance = 1e-3)
    
-  expect_equal(sum(norm_matched$reported_growth, na.rm=T), 35617)  
+  expect_equal(sum(norm_matched$reported_growth, na.rm=T), 53164)  
 })
 
 
@@ -145,22 +145,27 @@ test_that("growth_norm_lookup with unsanctioned windows", {
   norm_matched <- growth_norm_lookup(
     score_matched, processed_cdf, norms_long, TRUE
   )
-  expect_equal(nrow(norm_matched), 21483)
+  expect_equal(nrow(norm_matched), 30227)
   expect_equal(ncol(norm_matched), 52)
   expect_equal(
     as.character(summary(norm_matched)[, 'typical_growth'][3]), 
-    "Median : 2.086  " 
+    "Median : 2.356  " 
   )
-  expect_equal(sum(norm_matched$reported_growth, na.rm=T), 43232.5)
+  expect_equal(sum(norm_matched$reported_growth, na.rm=T), 60779.5)
   
 })
 
 
-test_that("scaffold with no matching data returns empty", {
-  empty_scaffold <- student_scaffold(
+test_that("scaffold with no one season returns projections, but not performance", {
+  single_season_scaffold <- student_scaffold(
     processed_cdf = processed_cdf %>% dplyr::filter(fallwinterspring == 'Fall') 
    ,start_season = 'Fall'
    ,end_season = 'Spring'
    ,year_offset = 0
   )
+  
+  expect_equal(nrow(single_season_scaffold), 2186)
+  expect_equal(ncol(single_season_scaffold), 17)
+  expect_equal(sum(single_season_scaffold$start_grade_level_season), 13704.2)
+  expect_true(all(is.na(single_season_scaffold$end_grade_level_season)))
 })

--- a/tests/testthat/test_roster_to_df.R
+++ b/tests/testthat/test_roster_to_df.R
@@ -27,8 +27,8 @@ test_that("roster_to_growth_df tests", {
   )
   expect_equal(nrow(ex), nrow(mapviz$growth_df))
   expect_true('studentgender' %in% names(ex))
-  expect_equal(table(ex$studentgender)[1] %>% unname(), 8546)
-  expect_equal(table(ex$studentgender)[2] %>% unname(), 8464)
+  expect_equal(table(ex$studentgender)[1] %>% unname(), 12906)
+  expect_equal(table(ex$studentgender)[2] %>% unname(), 12848)
   
 })
 

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -252,10 +252,10 @@ test_that("mv_limit_cdf tests",{
 test_that("mv_limit_growth tests",{
 
   growth_df_limit <- mv_limit_growth(mapviz, studentids_normal_use, 'Mathematics')
-  expect_equal(nrow(growth_df_limit), 576)
+  expect_equal(nrow(growth_df_limit), 948)
   expect_equal(sum(growth_df_limit$cgi, na.rm=TRUE),  6.72, tolerance = 0.01)
-  expect_equal(sum(growth_df_limit$typical_growth, na.rm=TRUE), 2077, tolerance = 0.01)
-  expect_equal(sum(growth_df_limit$accel_growth, na.rm=TRUE), 3511, tolerance = 0.01)
+  expect_equal(sum(growth_df_limit$typical_growth, na.rm=TRUE), 3202, tolerance = 0.01)
+  expect_equal(sum(growth_df_limit$accel_growth, na.rm=TRUE), 5464, tolerance = 0.01)
 })
 
 


### PR DESCRIPTION
@almartin82: This should fix that scaffolding problem we talked about yesterday.  Essentially if the data only contains  a valid start season (which is all of them now), then the scaffold is built and then projected measures will be added to `growth_df`.  If you were to have crazy seasons  (say summer to summer, which makes no sense, but go with me here) then scaffold_students returns an empty data frame with proper types for each column (ensuring a later join returns and empty data.frame).  So I think this is working properly, but you should probably take a close look before merging. 
