### PR TITLE
ggplot version bump fixes

### DIFF
--- a/R/cgp_prep.R
+++ b/R/cgp_prep.R
@@ -47,7 +47,7 @@ calc_cgp <- function(
     vt$measurementscale, vt$end_grade, vt$growth_window, sep = '@'
   )
   if (!in_study) {
-    if (verbose) warning("measurementscale/grade/growth window combination isn't in school growth study.")
+    if (verbose) message("measurementscale/grade/growth window combination isn't in school growth study.")
     return(list("targets" = NA_real_, "results" = NA_real_))
     
   }

--- a/R/college_plots.R
+++ b/R/college_plots.R
@@ -162,16 +162,14 @@ rit_height_weight_npr <- function(
       data = e$df[e$df$rib == 'below_1', ],
       aes(x = x, ymin = ymin, ymax = ymax),
       fill = color_list[1],
-      alpha = ribbon_alpha,
-      environment = e
+      alpha = ribbon_alpha
     )
     
     e$rib_above_99 <- ggplot2::geom_ribbon(
       data = e$df[e$df$rib == 'above_99', ],
       aes(x = x, ymin = ymin, ymax = ymax),
       fill = color_list[14],
-      alpha = ribbon_alpha,
-      environment = e
+      alpha = ribbon_alpha
     )
  
    for (i in 1:length(e$ribbons)) {
@@ -181,8 +179,7 @@ rit_height_weight_npr <- function(
        data = e$df[e$df$rib == e$ribbons[i], ],
        aes(x = x, ymin = ymin, ymax = ymax),
        fill = color_list[i + 1],
-       alpha = ribbon_alpha,
-       environment = e       
+       alpha = ribbon_alpha  
      )
      
      #appropriate df
@@ -398,8 +395,7 @@ rit_height_weight_ACT <- function(
         data = inner_df,
         aes(x = x, ymin = ymin, ymax = ymax),
         fill = color_list[i + 1],
-        alpha = active_settings$ribbon_alpha,
-        environment = e      
+        alpha = active_settings$ribbon_alpha
       )
     
       #assign variable name
@@ -1147,7 +1143,6 @@ build_student_1year_goal_plot <- function(
       y = y,
       label = label
     ),
-    shape = 3,
     color = 'red',
     size = 5,
     alpha = 0.9,
@@ -1171,7 +1166,6 @@ build_student_1year_goal_plot <- function(
       y = y,
       label = label
     ),
-    shape = 3,
     color = 'red',
     size = 5,
     alpha = 0.9,

--- a/R/fuzz_test.R
+++ b/R/fuzz_test.R
@@ -102,14 +102,11 @@ silly_plot <- function(mapvizieR_obj, studentids) {
 #' @param studentids a vector of studentids
 
 error_ridden_plot <- function(mapvizieR_obj, studentids) {
-  cdf <- mapvizieR_obj[['cdf']]
-  cdf <- cdf[cdf$studentid == 'pancakes', ]
-  
   p <- ggplot(
-    data = cdf
-    ,aes(x = testritscore)
+    data = pancakes,
+    aes(x = testritscore)
   ) +
-    geom_histogram()
+  geom_histogram()
   
   return(p)
 }

--- a/R/student_npr_two_term_plot.R
+++ b/R/student_npr_two_term_plot.R
@@ -2,7 +2,7 @@
 #'
 #' @param mapvizieR_obj a \code{\link{mapvizieR}} object
 #' @param studentids a set of student ids to subset to
-#' @param measurement_scale a MAP measurementscale
+#' @param measurementscale a MAP measurementscale
 #' @param term_first the first test term. You need to use the full name, such
 #' as 'Spring 2012-2013'
 #' @param term_second the second test term. You need to use the full name, such
@@ -32,122 +32,128 @@
 #' student_npr_two_term_plot(
 #'   map_mv,
 #'   studentids = ids[1:80, "StudentID"],
-#'   measurement_scale ="Reading", 
+#'   measurementscale ="Reading", 
 #'   term_first = "Spring 2012-2013", 
 #'   term_second = "Fall 2013-2014", 
 #'   n_col = 7, 
 #'   min_n = 5)
 #'}
-student_npr_two_term_plot <- function(mapvizieR_obj,
-                                      studentids,
-                                      measurement_scale = "Reading",
-                                      term_first, 
-                                      term_second, 
-                                      n_col=9, 
-                                      min_n=10) {
+
+student_npr_two_term_plot <- function(
+  mapvizieR_obj,
+  studentids,
+  measurementscale = "Reading",
+  term_first, 
+  term_second, 
+  n_col = 9, 
+  min_n = 10
+) {
   
   if (! is.mapvizieR(mapvizieR_obj)){
     stop("The object you passed is not a conforming mapvizieR object")
   } 
   
+  #nse problems
+  measurementscale_in <- measurementscale
+  
   .data <- mapvizieR_obj$cdf
 
   .data <- .data %>%
-    dplyr::filter(termname %in% c(term_first, term_second), 
-                  studentid %in% studentids,
-                  measurementscale == measurement_scale
-                  ) %>%
-    dplyr::mutate(termname = factor(as.character(termname), 
-                                  levels = c(term_first, term_second)
-                                  )
-                  ) %>%
-    dplyr::inner_join(mapvizieR_obj$roster,
-                      by = c("studentid",
-                             "termname",
-                             "fallwinterspring",
-                             "map_year_academic",
-                             "grade"))
+    dplyr::filter(
+      termname %in% c(term_first, term_second), 
+      studentid %in% studentids,
+      measurementscale == measurementscale_in
+    ) %>%
+    dplyr::mutate(
+      termname = factor(
+        as.character(termname), levels = c(term_first, term_second)
+      )
+    ) %>%
+    dplyr::inner_join(
+      mapvizieR_obj$roster,
+      by = c("studentid", "termname", "fallwinterspring",
+             "map_year_academic", "grade")
+    )
   
   .data_joined <- 
-    dplyr::inner_join(dplyr::filter(.data, termname == term_first), 
-                      dplyr::filter(.data, termname == term_second),
-                      by = c("studentid", "measurementscale")
-                      )  %>%
+    dplyr::inner_join(
+      x = dplyr::filter(.data, termname == term_first), 
+      y = dplyr::filter(.data, termname == term_second),
+        by = c("studentid", "measurementscale")
+    ) %>%
     dplyr::mutate(
-           diff_pctl = consistent_percentile.y-consistent_percentile.x,
-           diff_bool = diff_pctl >= 0,
-           diff_rit =  testritscore.y-testritscore.x,
-           diff_rit_se = sqrt(teststandarderror.y^2 + teststandarderror.x^2),
-           diff_rit_bool = (0 >= -2 * diff_rit_se + diff_rit) & 
-                              (0 <= 2 * diff_rit_se + diff_rit),
-           diff_rit_neg_pos = ifelse(diff_rit_bool == FALSE & 
-                                       diff_rit > 0, 
-                                     "Positive",
-                                     ifelse(diff_rit_bool == FALSE & 
-                                              diff_rit < 0, 
-                                            "Negative", 
-                                            "Zero"
-                                            )
-                                     ),
-           diff_rit_neg_pos = factor(diff_rit_neg_pos, 
-                                     levels=c("Zero", 
-                                              "Negative", 
-                                              "Positive"
-                                              )
-                                     ),
-           studentname=paste(studentfirstname.x,
-                             studentlastname.x),
-           name=factor(studentname, levels=unique(studentname)[order(-diff_pctl)])
+      diff_pctl = consistent_percentile.y-consistent_percentile.x,
+      diff_bool = diff_pctl >= 0,
+      diff_rit =  testritscore.y-testritscore.x,
+      diff_rit_se = sqrt(teststandarderror.y^2 + teststandarderror.x^2),
+      diff_rit_bool = (0 >= -2 * diff_rit_se + diff_rit) & 
+        (0 <= 2 * diff_rit_se + diff_rit),
+      diff_rit_neg_pos = ifelse(
+        diff_rit_bool == FALSE & diff_rit > 0, 
+        "Positive",
+        ifelse(
+          diff_rit_bool == FALSE & diff_rit < 0, 
+          "Negative", 
+          "Zero"
+        )
+      ),
+      diff_rit_neg_pos = factor(
+        diff_rit_neg_pos, levels = c("Zero", "Negative", "Positive")
+      ),
+      studentname = paste(studentfirstname.x, studentlastname.x),
+      name = factor(
+        studentname, levels = unique(studentname)[order(-diff_pctl)]
+      )
     )
   
   if (nrow(.data_joined) < min_n) {
-    return(message(paste("Returning without generating plot:\n",
-                         "Number of students is fewer than",
-                         min_n
-                         )
-                   )
-           )
+    return(
+      message(
+        paste("Returning without generating plot:\n",
+              "Number of students is fewer than", min_n)
+      )
+    )
   }
-  
   
   .data_joined_2 <- .data_joined %>%
     dplyr::select(-name)
-  
 
-  
   #format terms
-  t1<-gsub("(.+)\\s(.+)", "\\1\n\\2", term_first)
-  t2<-gsub("(.+)\\s(.+)", "\\1\n\\2", term_second)
-  p<-ggplot(.data_joined, 
-            aes(x=0,
-                y=consistent_percentile.x)
-  ) + 
-    geom_segment(data=.data_joined_2, 
-                 aes(xend=1,
-                     yend=consistent_percentile.y,
-                     group=studentid
-                 ), 
-                 alpha=.1) +
-    geom_segment(aes(xend=1,
-                     yend=consistent_percentile.y,
-                     group=studentid,,
-                     color=diff_rit_neg_pos), 
-                 size=2) +
-    scale_x_continuous(name="Test Term", breaks=c(0, 1), labels=c(t1,t2)) +
-    scale_color_manual("RIT Difference\nis statistically:",values = c('#439539', #green
-                                                                      '#F7941E', # Orange
-                                                                      "purple"
-                                                                      # True 
-    )
+  t1 <- gsub("(.+)\\s(.+)", "\\1\n\\2", term_first)
+  t2 <- gsub("(.+)\\s(.+)", "\\1\n\\2", term_second)
+  p <- ggplot(.data_joined, aes(x = 0, y = consistent_percentile.x)) + 
+    geom_segment(
+      data = .data_joined_2, 
+      aes(
+        xend = 1,
+        yend = consistent_percentile.y,
+        group = studentid
+      ), 
+      alpha = .1
     ) +
-    facet_wrap(~name,ncol = n_col) + 
+    geom_segment(
+      aes(
+        xend = 1,
+        yend = consistent_percentile.y,
+        group = studentid,
+        color = diff_rit_neg_pos
+      ), 
+      size=2
+    ) +
+    scale_x_continuous(
+      name = "Test Term", breaks = c(0, 1), labels = c(t1, t2)
+    ) +
+    scale_color_manual(
+      "RIT Difference\nis statistically:", 
+      values = c('#439539', #green
+                 '#F7941E', # Orange
+                 "purple"# True 
+      )
+    ) +
+    facet_wrap(~ name,ncol = n_col) + 
     theme_bw() + 
-    theme(axis.text.x=element_text(hjust=c(0,1))) +
+    theme(axis.text.x = element_text(hjust = c(0, 1))) +
     ylab("Test Percentile")
   
   p
-  
-  
-  
 }
-  

--- a/man/student_npr_two_term_plot.Rd
+++ b/man/student_npr_two_term_plot.Rd
@@ -5,7 +5,7 @@
 \title{A small multiples plot of a set of students' national percentile rank over two terms.}
 \usage{
 student_npr_two_term_plot(mapvizieR_obj, studentids,
-  measurement_scale = "Reading", term_first, term_second, n_col = 9,
+  measurementscale = "Reading", term_first, term_second, n_col = 9,
   min_n = 10)
 }
 \arguments{
@@ -13,7 +13,7 @@ student_npr_two_term_plot(mapvizieR_obj, studentids,
 
 \item{studentids}{a set of student ids to subset to}
 
-\item{measurement_scale}{a MAP measurementscale}
+\item{measurementscale}{a MAP measurementscale}
 
 \item{term_first}{the first test term. You need to use the full name, such
 as 'Spring 2012-2013'}
@@ -51,7 +51,7 @@ ids <- ex_CombinedStudentsBySchool \%>\%
 student_npr_two_term_plot(
   map_mv,
   studentids = ids[1:80, "StudentID"],
-  measurement_scale ="Reading", 
+  measurementscale ="Reading", 
   term_first = "Spring 2012-2013", 
   term_second = "Fall 2013-2014", 
   n_col = 7, 

--- a/tests/testthat/test_becca.R
+++ b/tests/testthat/test_becca.R
@@ -14,8 +14,9 @@ test_that("becca_plot produces proper plot with a grade level of kids", {
   p_build <- ggplot2::ggplot_build(p)
   expect_true(is.ggplot(p))
   expect_equal(nrow(p_build$data[[1]]), 6)
-  expect_equal(ncol(p_build$data[[2]]), 10)
-  expect_equal(sum(p_build$data[[3]][, 2]), 133.871, tolerance=.001)
+  expect_equal(ncol(p_build$data[[2]]), 14)
+  expect_equal(sum(p_build$data[[3]][, 2]), 133.871, tolerance = .001)
+
 })
 
 
@@ -33,34 +34,34 @@ test_that("becca_plot returns expected data with a variety of groupings of kids"
   p_build <- ggplot2::ggplot_build(p)
   expect_true(is.ggplot(p))
   expect_equal(nrow(p_build$data[[1]]), 12)
-  expect_equal(ncol(p_build$data[[1]]), 10)
-  expect_equal(sum(p_build$data[[2]][, 3]), -398.8634, tolerance=.001)
-  expect_equal(sum(p_build$data[[3]][, 2]), 358.9267, tolerance=.001)
+  expect_equal(ncol(p_build$data[[1]]), 14)
+  expect_equal(sum(p_build$data[[2]][, 3]), -269.1622, tolerance = .001)
+  expect_equal(sum(p_build$data[[3]][, 2]), 358.9267, tolerance = .001)
 
   p <- becca_plot(mapviz, studentids_subset, 'Mathematics', first_and_spring_only=TRUE,
     entry_grade_seasons=c(7.2), small_n_cutoff=0.3)
   p_build <- ggplot2::ggplot_build(p)
   expect_true(is.ggplot(p))
   expect_equal(nrow(p_build$data[[1]]), 16)
-  expect_equal(ncol(p_build$data[[1]]), 10)
-  expect_equal(sum(p_build$data[[2]][, 3]), -648.1719, tolerance=.001)
-  expect_equal(sum(p_build$data[[3]][, 2]),  456.7542, tolerance=.001)
+  expect_equal(ncol(p_build$data[[1]]), 14)
+  expect_equal(sum(p_build$data[[2]][, 3]), -429.7291, tolerance = .001)
+  expect_equal(sum(p_build$data[[3]][, 2]),  456.7542, tolerance = .001)
 
   p <- becca_plot(mapviz, studentids_normal_use, 'Mathematics', detail_academic_year=2016)
   p_build <- ggplot2::ggplot_build(p)
   expect_true(is.ggplot(p))
   expect_equal(nrow(p_build$data[[1]]), 2)
-  expect_equal(ncol(p_build$data[[1]]), 10)
-  expect_equal(sum(p_build$data[[2]][, 3]), -110.7527, tolerance=.001)
-  expect_equal(sum(p_build$data[[3]][, 2]), 46.77419, tolerance=.001)
+  expect_equal(ncol(p_build$data[[1]]), 14)
+  expect_equal(sum(p_build$data[[2]][, 3]), -76.34409, tolerance = .001)
+  expect_equal(sum(p_build$data[[3]][, 2]), 46.77419, tolerance = .001)
   
   p <- becca_plot(mapviz, studentids_normal_use, 'Mathematics', first_and_spring_only=FALSE)
   p_build <- ggplot2::ggplot_build(p)
   expect_true(is.ggplot(p))
   expect_equal(nrow(p_build$data[[1]]), 6)
-  expect_equal(ncol(p_build$data[[1]]), 10)
-  expect_equal(sum(p_build$data[[2]][, 3]), -330.1075, tolerance=.001)
-  expect_equal(sum(p_build$data[[3]][, 2]), 133.871, tolerance=.001)
+  expect_equal(ncol(p_build$data[[1]]), 14)
+  expect_equal(sum(p_build$data[[2]][, 3]), -256.9892, tolerance = .001)
+  expect_equal(sum(p_build$data[[3]][, 2]), 133.871, tolerance = .001)
   
   #alt colors
   p <- becca_plot(mapviz, studentids_subset, 'Mathematics', color_scheme='Sequential Blues')
@@ -80,15 +81,19 @@ test_that("becca_plot returns expected data with a variety of groupings of kids"
 test_that("fuzz test becca_plot plot", {
   results <- fuzz_test_plot(
     'becca_plot', 
-    n=25,
-    additional_args=list('measurementscale'='Mathematics', 'detail_academic_year'=2013)
+    n = 10,
+    additional_args = list(
+      'measurementscale' = 'Mathematics', 'detail_academic_year' = 2013
+    )
   )
   expect_true(all(unlist(results)))
   
   results <- fuzz_test_plot(
-   plot_name='becca_plot', 
-   n=25, 
-   additional_args=list("first_and_spring_only"=FALSE, 'measurementscale'='Mathematics')
+    plot_name = 'becca_plot', 
+    n = 10, 
+    additional_args = list(
+     "first_and_spring_only" = FALSE, 'measurementscale' = 'Mathematics'
+    )
  )
  expect_true(all(unlist(results)))
  

--- a/tests/testthat/test_becca.R
+++ b/tests/testthat/test_becca.R
@@ -84,7 +84,8 @@ test_that("fuzz test becca_plot plot", {
     n = 10,
     additional_args = list(
       'measurementscale' = 'Mathematics', 'detail_academic_year' = 2013
-    )
+    ),
+    mapvizieR_obj = mapviz
   )
   expect_true(all(unlist(results)))
   
@@ -93,7 +94,8 @@ test_that("fuzz test becca_plot plot", {
     n = 10, 
     additional_args = list(
      "first_and_spring_only" = FALSE, 'measurementscale' = 'Mathematics'
-    )
+    ),
+    mapvizieR_obj = mapviz
  )
  expect_true(all(unlist(results)))
  

--- a/tests/testthat/test_cohort_cgp.R
+++ b/tests/testthat/test_cohort_cgp.R
@@ -23,7 +23,7 @@ test_that("cohort_cgp_hist_plot should return a plot", {
   
   expect_is(p2, 'ggplot')
   p2 <- ggplot_build(p2)
-  expect_equal(p2$data[[5]][1,] %>% sum(na.rm = TRUE) %>% round(2), 102.88)
+  expect_equal(p2$data[[5]][1,1:2] %>% sum(na.rm = TRUE) %>% round(2), 89.68)
   
 })
 

--- a/tests/testthat/test_elephants.R
+++ b/tests/testthat/test_elephants.R
@@ -49,15 +49,20 @@ test_that("galloping_elephants returns expected data with a nonsense grouping of
 test_that("fuzz test elephants plot", {
   results <- fuzz_test_plot(
     'galloping_elephants', 
-    n=25,
-    additional_args=list('measurementscale'='Mathematics')
+    n = 25,
+    additional_args = list('measurementscale' = 'Mathematics'),
+    mapvizieR_obj = mapviz
   )
   expect_true(all(unlist(results)))
   
   results <- fuzz_test_plot(
    plot_name = 'galloping_elephants', 
    n = 25, 
-   additional_args=list("first_and_spring_only" = FALSE, 'measurementscale' = 'Mathematics')
+   additional_args = list(
+     "first_and_spring_only" = FALSE, 
+     'measurementscale' = 'Mathematics'
+    ),
+   mapvizieR_obj = mapviz
  )
  expect_true(all(unlist(results)))
  

--- a/tests/testthat/test_fuzz_test.R
+++ b/tests/testthat/test_fuzz_test.R
@@ -10,9 +10,9 @@ test_that("fuzz test a vanilla ggplot", {
 })
 
 
-test_that("fuzz test a vanilla ggplot", {    
+test_that("fuzz test a broken ggplot", {    
   results <- fuzz_test_plot('error_ridden_plot', n = 3, mapvizieR_obj = mapviz)
-  expect_false(all(unlist(results)))
+  expect_false(any(unlist(results)))
 })
 
 

--- a/tests/testthat/test_goalbar.R
+++ b/tests/testthat/test_goalbar.R
@@ -71,8 +71,9 @@ test_that("goalbar should throw a warning if some students cant be categorized",
 test_that("goalbar should throw a error if no students have normative data",{
     
   expect_error(
-    goalbar(mapviz, studentids_gr11, 'Mathematics', 'Fall', 2013,
-         'Spring', 2013),
+    goalbar(
+      mapviz, studentids_gr11, 'Mathematics', 'Fall', 2013, 'Spring', 2013
+    ),
     "Sorry, can't plot that: None of the students in your selection have typical growth norms"
   )
            
@@ -80,13 +81,19 @@ test_that("goalbar should throw a error if no students have normative data",{
 
 
 test_that("fuzz test goalbar plot", {
+  
   results <- fuzz_test_plot(
-    'goalbar', 
-    n=10,
-    additional_args=list('measurementscale' = 'Mathematics', 'start_fws' = 'Fall',
-      'start_academic_year' = 2013, 'end_fws' = 'Spring', 'end_academic_year' = 2013)
+    plot_name = 'goalbar', 
+    n = 10,
+    additional_args = list(
+      'measurementscale' = 'Mathematics', 'start_fws' = 'Fall',
+      'start_academic_year' = 2013, 'end_fws' = 'Spring', 
+      'end_academic_year' = 2013
+    ),
+    mapvizieR_obj = mapviz
   )
   expect_true(all(unlist(results)))
+  
 })
 
 

--- a/tests/testthat/test_goalbar.R
+++ b/tests/testthat/test_goalbar.R
@@ -16,7 +16,7 @@ test_that("goalbar produces proper plot with a grade level of kids", {
   expect_true(is.ggplot(p))
   expect_equal(nrow(p_build$data[[1]]), 4)
   expect_equal(sum(p_build$data[[1]][, 6]), 155, tolerance=.001)  
-  expect_equal(ncol(p_build$data[[2]]), 6)
+  expect_equal(ncol(p_build$data[[2]]), 15)
   expect_equal(sum(p_build$data[[2]][, 3]), 201.5, tolerance=.001)
   
   p <- goalbar(mapviz, studentids_normal_use, 'Mathematics', 'Fall', 2013,
@@ -25,7 +25,7 @@ test_that("goalbar produces proper plot with a grade level of kids", {
   expect_true(is.ggplot(p))
   expect_equal(nrow(p_build$data[[1]]), 4)
   expect_equal(sum(p_build$data[[1]][, 6]), 155, tolerance=.001)  
-  expect_equal(ncol(p_build$data[[2]]), 6)
+  expect_equal(ncol(p_build$data[[2]]), 15)
   expect_equal(sum(p_build$data[[2]][, 3]), 201.5, tolerance=.001)
 
 })

--- a/tests/testthat/test_growth_status_scatter.R
+++ b/tests/testthat/test_growth_status_scatter.R
@@ -45,7 +45,8 @@ test_that("fuzz test growth_status_scatter", {
       'start_academic_year' = 2013,
       'end_fws' = 'Spring',
       'end_academic_year' = 2013
-    )
+    ),
+    mapvizieR_obj = mapviz
   )
   expect_true(all(unlist(results))) 
 })

--- a/tests/testthat/test_growth_status_scatter.R
+++ b/tests/testthat/test_growth_status_scatter.R
@@ -23,7 +23,12 @@ test_that("growth_status_scatter produces proper plot with a grade level of kids
   p_build <- ggplot_build(samp_scatter)
   
   expect_equal(length(p_build), 3)
-  expect_equal(dimnames(p_build[[1]][[2]])[[2]], c("x", "y", "PANEL", "group"))
+  expect_equal(
+    dimnames(p_build[[1]][[2]])[[2]], 
+    c("x", "y", "PANEL", "group", "colour", "size", "angle", "hjust", 
+      "vjust", "alpha", "family", "fontface", "lineheight", "label"
+    )
+  )
   expect_equal(sum(p_build[[1]][[2]]$x), 298, tolerance = 0.01)
   
 })

--- a/tests/testthat/test_haid_plot.R
+++ b/tests/testthat/test_haid_plot.R
@@ -33,7 +33,8 @@ test_that("haid_plot produces proper plot with a grade level of kids", {
   expect_equal(length(p_build), 3)
   expect_equal(
     dimnames(p_build[[1]][[2]])[[2]],
-    c("y", "x", "PANEL", "group")
+    c("y", "x", "PANEL", "group", "shape", "colour", "size", "fill", 
+      "alpha", "stroke")
   )
   expect_equal(sum(p_build[[1]][[5]]$xend), 19884, tolerance=0.01)
   
@@ -65,7 +66,8 @@ test_that("haid_plot with one season of data", {
   expect_equal(length(p_build), 3)
   expect_equal(
     dimnames(p_build[[1]][[2]])[[2]],
-    c("y", "x", "PANEL", "group")
+    c("y", "x", "PANEL", "group", "shape", "colour", "size", "fill", 
+      "alpha", "stroke")
   )
   expect_equal(sum(p_build[[1]][[5]]$x), 20744.75, tolerance=0.01)
   

--- a/tests/testthat/test_historic_recap_report.R
+++ b/tests/testthat/test_historic_recap_report.R
@@ -26,7 +26,7 @@ test_that("historic recap report produces valid plot", {
   expect_is(p, 'grob')
   expect_is(p, 'gtable')
   expect_equal(
-    p$grobs[[2]][[1]][[2]][[1]][[11]]$children$axis$grobs[[2]]$x,
+    p$grobs[[2]][[1]][[2]][[1]][[11]]$children$axis$grobs[[2]]$children[[1]]$x,
     structure(
       c(0.850649350649351, 0.928571428571429, 0.590909090909091, 
         0.668831168831169, 0.331168831168831, 0.409090909090909, 0.0714285714285713, 

--- a/tests/testthat/test_kipp_typ.R
+++ b/tests/testthat/test_kipp_typ.R
@@ -1,4 +1,4 @@
-context("typical growth distribution")
+context("kipp typical growth")
 
 test_that("growth distribution should return a bar plot", {  
   typ_test <- kipp_typ_growth_distro(
@@ -16,7 +16,7 @@ test_that("growth distribution should return a bar plot", {
   p_build <- ggplot2::ggplot_build(typ_test)
   expect_true(is.ggplot(typ_test))
   expect_equal(nrow(p_build$data[[1]]), 26)
-  expect_equal(ncol(p_build$data[[2]]), 5)
+  expect_equal(ncol(p_build$data[[2]]), 15)
 })  
 
 
@@ -36,6 +36,6 @@ test_that("growth distribution with big data set", {
   p_build <- ggplot2::ggplot_build(typ_test)
   expect_true(is.ggplot(typ_test))
   expect_equal(nrow(p_build$data[[1]]), 101)
-  expect_equal(ncol(p_build$data[[2]]), 5)
+  expect_equal(ncol(p_build$data[[2]]), 15)
 })  
 

--- a/tests/testthat/test_sgp_histogram.R
+++ b/tests/testthat/test_sgp_histogram.R
@@ -95,6 +95,7 @@ test_that("growth_histogram produces proper plot with a grade level of kids", {
 
 
 test_that("fuzz test growth_histogram", {
+  
   results <- fuzz_test_plot(
     'growth_histogram', 
     n = 10,
@@ -104,8 +105,10 @@ test_that("fuzz test growth_histogram", {
       'start_academic_year' = 2013,
       'end_fws' = 'Spring',
       'end_academic_year' = 2013
-    )
+    ),
+    mapvizieR_obj = mapviz
   )
   expect_true(all(unlist(results))) 
+  
 })
 

--- a/tests/testthat/test_sgp_histogram.R
+++ b/tests/testthat/test_sgp_histogram.R
@@ -1,4 +1,4 @@
-context("growth_histogram tests")
+context("sgp histogram tests")
 
 test_that("growth_histogram errors when handed an improper mapviz object", {
   expect_error(
@@ -33,8 +33,9 @@ test_that("growth_histogram produces proper plot with a grade level of kids", {
   expect_equal(length(p_build), 3)
   expect_equal(
     dimnames(p_build[[1]][[2]])[[2]],
-    c("y", "count", "x", "ndensity", "ncount", "density", "PANEL", 
-      "group", "ymin", "ymax", "xmin", "xmax")
+    c("y", "count", "x", "density", "ncount", "ndensity", "PANEL", 
+      "group", "ymin", "ymax", "xmin", "xmax", "colour", "fill", "size", 
+      "linetype", "alpha")
   )
   expect_equal(sum(p_build[[1]][[2]]$density), 0.1, tolerance = 0.01)
   

--- a/tests/testthat/test_strand_boxes.R
+++ b/tests/testthat/test_strand_boxes.R
@@ -22,7 +22,7 @@ test_that("strand boxes produces proper plot with a grade level of kids", {
   expect_true(is.ggplot(p))
   expect_equal(nrow(p_build$data[[1]]), 4)
   expect_equal(sum(p_build$data[[1]][, 3]), 894, tolerance = .001)  
-  expect_equal(ncol(p_build$data[[2]]), 5)
+  expect_equal(ncol(p_build$data[[2]]), 16)
   expect_equal(sum(p_build$data[[2]][, 2]), 0, tolerance = .001)
   
 })

--- a/tests/testthat/test_strand_boxes.R
+++ b/tests/testthat/test_strand_boxes.R
@@ -29,11 +29,16 @@ test_that("strand boxes produces proper plot with a grade level of kids", {
 
 
 test_that("fuzz test strand boxes plot", {
+  
   results <- fuzz_test_plot(
-    'strand_boxes', n = 10,
+    plot_name = 'strand_boxes', 
+    n = 10,
     additional_args = list(
-      'measurementscale' = 'Mathematics', 'fws' = 'Fall', 'academic_year' = 2013
-    )
+      'measurementscale' = 'Mathematics', 'fws' = 'Fall', 
+      'academic_year' = 2013
+    ),
+    mapvizieR_obj = mapviz
   )
   expect_true(all(unlist(results)))
+  
 })

--- a/tests/testthat/test_strand_list.R
+++ b/tests/testthat/test_strand_list.R
@@ -1,4 +1,4 @@
-context("strands_list_plot tests")
+context("strand list plot tests")
 
 test_that("strands_list_plot errors when handed an improper mapviz object", {
   expect_error(
@@ -9,29 +9,32 @@ test_that("strands_list_plot errors when handed an improper mapviz object", {
 
 
 test_that("student_npr_two_term_plot produces proper plot with a grade level of kids", {
-  p <- strands_list_plot(mapvizier_obj = mapviz,   
-                         studentids = studentids_normal_use, 
-                         measurement_scale = "Reading", 
-                         season = "Spring", 
-                         year= 2013)
-  
+  p <- strands_list_plot(
+    mapvizier_obj = mapviz,   
+    studentids = studentids_normal_use, 
+    measurement_scale = "Reading", 
+    season = "Spring", 
+    year = 2013
+  )
   
   p_build <- ggplot_build(p)
   expect_true(is.ggplot(p))
   expect_equal(nrow(p_build$data[[1]]), 279)
-  expect_equal(ncol(p_build$data[[2]]), 6)
+  expect_equal(ncol(p_build$data[[2]]), 14)
   expect_equal(sum(p_build$data[[2]][, 2]), 59584, tolerance = .001)
 })
 
-# this is taking way too long to run!!!
-# test_that("fuzz test s plot", {
-#   results <- fuzz_test_plot(
-#     'strands_list_plot', 
-#     n = 1,
-#     additional_args=list( 
-#                           "measurement_scale" = "Reading", 
-#                           "season" = "Spring", 
-#                           "year"= 2013)
-#   )
-#   expect_true(all(unlist(results)))
-# })
+#this is taking way too long to run!!!
+test_that("fuzz test s plot", {
+  results <- fuzz_test_plot(
+    plot_name = 'strands_list_plot', 
+    n = 1,
+    additional_args = list( 
+      "measurement_scale" = "Reading", 
+      "season" = "Spring", 
+      "year"= 2013
+    ),
+    mapvizieR_obj = mapviz
+  )
+  expect_true(all(unlist(results)))
+})

--- a/tests/testthat/test_student_npr_history.R
+++ b/tests/testthat/test_student_npr_history.R
@@ -28,9 +28,10 @@ test_that("student_npr_history_plot produces proper plot with a grade level of k
 
 test_that("fuzz test student_npr_history_plot plot", {
   results <- fuzz_test_plot(
-    'student_npr_history_plot', 
+    plot_name = 'student_npr_history_plot', 
     n = 5,
-    additional_args=list('measurementscale' = 'Mathematics')
+    additional_args = list('measurementscale' = 'Mathematics'),
+    mapvizieR_obj = mapviz
   )
   expect_true(all(unlist(results)))
 })

--- a/tests/testthat/test_student_npr_history.R
+++ b/tests/testthat/test_student_npr_history.R
@@ -21,7 +21,7 @@ test_that("student_npr_history_plot produces proper plot with a grade level of k
   p_build <- ggplot_build(p)
   expect_true(is.ggplot(p))
   expect_equal(nrow(p_build$data[[1]]), 160)
-  expect_equal(ncol(p_build$data[[2]]), 4)
+  expect_equal(ncol(p_build$data[[2]]), 10)
   expect_equal(sum(p_build$data[[3]][, 2]), 320, tolerance = .001)
 })
 

--- a/tests/testthat/test_student_npr_two_term.R
+++ b/tests/testthat/test_student_npr_two_term.R
@@ -5,7 +5,7 @@ test_that("student_npr_two_year_plot errors when handed an improper mapviz objec
     student_npr_two_term_plot(
       mapvizieR_obj = cdf,
       studentids = studentids_normal_use,
-      measurement_scale = "Reading", 
+      measurementscale = "Reading", 
       term_first = "Spring 2012-2013", 
       term_second = "Fall 2013-2014", 
       n_col = 7, 
@@ -19,7 +19,7 @@ test_that("student_npr_two_term_plot produces proper plot with a grade level of 
   p <- student_npr_two_term_plot(
     mapvizieR_obj = mapviz,
     studentids = studentids_normal_use,
-    measurement_scale = "Reading", 
+    measurementscale = "Reading", 
     term_first = "Spring 2012-2013", 
     term_second = "Fall 2013-2014", 
     n_col = 7, 
@@ -37,9 +37,9 @@ test_that("student_npr_two_term_plot produces proper plot with a grade level of 
 test_that("fuzz test student_npr_two_term_plot plot", {
   results <- fuzz_test_plot(
     'student_npr_two_term_plot', 
-    n = 10,
+    n = 5,
     additional_args = list(
-      'measurement_scale' = "Reading", 
+      'measurementscale' = "Reading", 
       'term_first' = "Spring 2012-2013", 
       'term_second' = "Fall 2013-2014", 
       'n_col' = 7, 

--- a/tests/testthat/test_student_npr_two_term.R
+++ b/tests/testthat/test_student_npr_two_term.R
@@ -2,32 +2,34 @@ context("student_npr_two_term_plot tests")
 
 test_that("student_npr_two_year_plot errors when handed an improper mapviz object", {
   expect_error(
-    student_npr_two_term_plot(cdf,
-                              studentids = studentids_normal_use,
-                              measurement_scale ="Reading", 
-                              term_first = "Spring 2012-2013", 
-                              term_second = "Fall 2013-2014", 
-                              n_col = 7, 
-                              min_n = 5),
+    student_npr_two_term_plot(
+      mapvizieR_obj = cdf,
+      studentids = studentids_normal_use,
+      measurement_scale = "Reading", 
+      term_first = "Spring 2012-2013", 
+      term_second = "Fall 2013-2014", 
+      n_col = 7, 
+      min_n = 5),
     "The object you passed is not a conforming mapvizieR object"
   )
 })
 
 
 test_that("student_npr_two_term_plot produces proper plot with a grade level of kids", {
-  p <- student_npr_two_term_plot(mapviz,
-                                 studentids = studentids_normal_use,
-                                 measurement_scale ="Reading", 
-                                 term_first = "Spring 2012-2013", 
-                                 term_second = "Fall 2013-2014", 
-                                 n_col = 7, 
-                                 min_n = 5)
+  p <- student_npr_two_term_plot(
+    mapvizieR_obj = mapviz,
+    studentids = studentids_normal_use,
+    measurement_scale = "Reading", 
+    term_first = "Spring 2012-2013", 
+    term_second = "Fall 2013-2014", 
+    n_col = 7, 
+    min_n = 5
+  )
                                 
-    
   p_build <- ggplot_build(p)
   expect_true(is.ggplot(p))
   expect_equal(nrow(p_build$data[[1]]), 1369)
-  expect_equal(ncol(p_build$data[[2]]), 7)
+  expect_equal(ncol(p_build$data[[2]]), 10)
   expect_equal(sum(p_build$data[[2]][, 4]), 1638, tolerance = .001)
 })
 
@@ -35,12 +37,15 @@ test_that("student_npr_two_term_plot produces proper plot with a grade level of 
 test_that("fuzz test student_npr_two_term_plot plot", {
   results <- fuzz_test_plot(
     'student_npr_two_term_plot', 
-    n = 5,
-    additional_args=list( 'measurement_scale' ="Reading", 
-                          'term_first' = "Spring 2012-2013", 
-                          'term_second' = "Fall 2013-2014", 
-                          'n_col' = 7, 
-                          'min_n' = 5)
+    n = 10,
+    additional_args = list(
+      'measurement_scale' = "Reading", 
+      'term_first' = "Spring 2012-2013", 
+      'term_second' = "Fall 2013-2014", 
+      'n_col' = 7, 
+      'min_n' = 5
+    ),
+    mapvizieR_obj = mapviz
   )
   expect_true(all(unlist(results)))
 })


### PR DESCRIPTION
@chrishaid TIL that failing tests in `testthat`:
- first get labeled `1, 2, 3, 4...` up to 8
- then get labeled `a, b, c, d` up to `z`.
- then get labeled `A, B, C`.

I'm not sure what happens after capital letters, thankfully.

most of these fixes were simply changes caused by `ggbuild` and the new oo system that he implemented for the new version.  However, especially for `college_plots.R`, the update got a little stricter about passing unused arguments -- for instance, `geom_ribbon()` no longer takes an `environment` argument, and `geom_text` can't take a `shape` argument.

presumably these were just being ignored by previous versions of ggplot, but now they are rejected and raising errors.

**other helpful stuff in here**
- there were a bunch of fuzz_test_plots that didn't have the pre-built/helper `mapviz` object specified, so _presumably_ those were rebuilding the mapviz object from scratch, every time (!?).  this _should_ speed up tests.
- I also cleaned up `student_npr_two_term_plot()` so that it takes standard `measurementscale`, not `measurement_scale`.  I understand why you were using that parameter (NSE problems with dplyr::filter) but we have a consistent strategy we are using elsewhere to solve that problem, and having inconsistencies in parameter arguments across plots seems like a bad look.
