### PR TITLE
College plot hotfix

### DIFF
--- a/R/localization.R
+++ b/R/localization.R
@@ -82,7 +82,5 @@ localize <- function(region, verbose = FALSE) {
     
   }
     
-  
   return(final_list)
 }
-

--- a/tests/testthat/test_college_plots.R
+++ b/tests/testthat/test_college_plots.R
@@ -217,3 +217,23 @@ test_that("bulk goal plot", {
   expect_equal(length(goal_ex), 20)
   expect_equal(goal_ex[[1]]$data$rit %>% sum(), 21765.1)
 })
+
+
+test_that("npr templates generate correctly with default localizations", {
+  
+  math_act <- rit_height_weight_ACT(
+    measurementscale = 'Mathematics',
+    localization = localize('default')
+  )
+  read_act <- rit_height_weight_ACT(
+    measurementscale = 'Reading',
+    localization = localize('default')
+  )
+
+  expect_is(math_act, 'ggplot')
+  expect_is(read_act, 'ggplot')
+  math_act <- ggplot_build(math_act)
+  expect_equal(math_act$data[[8]]$y %>% sum(), 18662.3)
+  read_act <- ggplot_build(read_act)
+  expect_equal(read_act$data[[8]]$y %>% sum(), 18090.7)
+})

--- a/tests/testthat/test_summary_mapvizier.R
+++ b/tests/testthat/test_summary_mapvizier.R
@@ -1,12 +1,11 @@
 context("mapvizier_summary tests")
 
-test_that("sumamry works as expected", {
+test_that("summary works as expected", {
   ex <- summary(mapviz)
-  expect_equal(ex$end_pct_75th_pctl %>% sum(na.rm = TRUE), 41.56)
-  expect_equal(nrow(ex), 346)
-  expect_equal(sum(ex$cgp, na.rm = TRUE), 7314.03)
+  expect_equal(ex$end_pct_75th_pctl %>% sum(na.rm = TRUE), 37.49)
+  expect_equal(nrow(ex), 149)
+  expect_equal(sum(ex$cgp, na.rm = TRUE), 7344.26)
   
   ex2 <- summary(mapviz, digits = 3)
-  expect_equal(ex2$end_pct_75th_pctl %>% sum(na.rm = TRUE), 41.544)
-  
+  expect_equal(ex2$end_pct_75th_pctl %>% sum(na.rm = TRUE), 37.462)
 })


### PR DESCRIPTION
@chrishaid I would merge this myself, but I want you to be aware of the changes to `summary()` -- old version did not filter growth_df on complete observation = TRUE, so kids coming in/out of cohort (via new enrollments) would enter into the stats.  changes were made a few pull requests ago, but for whatever reason the tests needed to be updated.

should we make that an argument?  I think current behavior is more expected for users, but it's worth thinking about.
